### PR TITLE
fix: incorrect indent in function & table

### DIFF
--- a/src/FormatVisitor.cpp
+++ b/src/FormatVisitor.cpp
@@ -1151,7 +1151,11 @@ antlrcpp::Any FormatVisitor::visitFunctiondef(LuaParser::FunctiondefContext* ctx
     LOG_FUNCTION_BEGIN("visitFunctiondef");
     cur_writer() << ctx->FUNCTION()->getText();
     cur_writer() << commentAfter(ctx->FUNCTION(), "");
+    // disable indentForAlign_ in function body
+    int temp = indentForAlign_;
+    indentForAlign_ = 0;
     visitFuncbody(ctx->funcbody());
+    indentForAlign_ = temp;
     LOG_FUNCTION_END("visitFunctiondef");
     return nullptr;
 }
@@ -1226,6 +1230,9 @@ antlrcpp::Any FormatVisitor::visitParlist(LuaParser::ParlistContext* ctx) {
 antlrcpp::Any FormatVisitor::visitTableconstructor(LuaParser::TableconstructorContext* ctx) {
     LOG_FUNCTION_BEGIN("visitTableconstructor");
     cur_writer() << ctx->LB()->getText();
+    // disable indentForAlign_ in table
+    int temp = indentForAlign_;
+    indentForAlign_ = 0;
     if (ctx->fieldlist() != NULL) {
         bool containsKv = false;
         bool chopDown = false;
@@ -1306,6 +1313,7 @@ antlrcpp::Any FormatVisitor::visitTableconstructor(LuaParser::TableconstructorCo
             cur_writer() << ctx->RB()->getText();
         }
     }
+    indentForAlign_ = temp;
     LOG_FUNCTION_END("visitTableconstructor");
     return nullptr;
 }

--- a/test/test_format_file.cpp
+++ b/test/test_format_file.cpp
@@ -30,6 +30,7 @@ using namespace std;
 TEST_FILE("../test/testdata/linebreak/args_length.lua");
 TEST_FILE("../test/testdata/linebreak/block.lua");
 TEST_FILE("../test/testdata/linebreak/chained_call_args.lua");
+TEST_FILE("../test/testdata/linebreak/disable_align_in_function.lua");
 TEST_FILE("../test/testdata/linebreak/functioncall.lua");
 TEST_FILE("../test/testdata/linebreak/functiondef.lua");
 TEST_FILE("../test/testdata/linebreak/indent_in_explist.lua");

--- a/test/testdata/linebreak/_disable_align_in_function.lua
+++ b/test/testdata/linebreak/_disable_align_in_function.lua
@@ -1,0 +1,9 @@
+longvarvarvarvarvar = function()
+    func(
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+end
+
+longvarvarvarvarvar = {
+    s = func(
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+}

--- a/test/testdata/linebreak/_functioncall.lua
+++ b/test/testdata/linebreak/_functioncall.lua
@@ -13,8 +13,8 @@ local x = function()
     ddd.www:map(function(it)
         it.aaa(wwww)(wwww)(wwww)(wwww) -- comment
         .wwwww(wwww)(wwww)(wwww)(wwww).wwwww(wwww)(wwww)(wwww)(wwww)
-                        .wwwww(wwww)(wwww)(wwww)(wwww).wwwww(wwww):wwwww(wwww)
-                        :wwwww(wwww):wwwww(wwww):wwwww(wwww):wwwww(wwww)
+            .wwwww(wwww)(wwww)(wwww)(wwww).wwwww(wwww):wwwww(wwww):wwwww(wwww)
+            :wwwww(wwww):wwwww(wwww):wwwww(wwww)
     end)
 end
 

--- a/test/testdata/linebreak/disable_align_in_function.lua
+++ b/test/testdata/linebreak/disable_align_in_function.lua
@@ -1,0 +1,7 @@
+longvarvarvarvarvar = function()
+    func("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+end
+
+longvarvarvarvarvar = {
+    s = func("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+}


### PR DESCRIPTION
fix incorrect indent in function body or table
when they are right value of assign statment