### PR TITLE
Added Dockerfile that creates image that contains LuaFormatter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:latest
+RUN apt update && apt upgrade -y && apt install g++ cmake git make -y
+RUN git clone https://github.com/Koihik/LuaFormatter.git /tmp/luaformatter && \
+    cd /tmp/luaformatter && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBUILD_TESTS=FALSE && \
+    cmake --build . --target install && \
+    rm -rf /tmp/luaformatter
+RUN apt remove g++ cmake git make -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
A public docker image built with this Dockerfile is available at https://cloud.docker.com/u/evbfirmware/repository/docker/evbfirmware/luaformatter. This is not actively maintained per se.