### PR TITLE
feature: add string literal transformation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,48 @@
 language: cpp
-sudo: false
 
 matrix:
   include:
 
     # linux gcc
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - ['g++-9']
       env:
          - COMPILER='g++-9'
 
     # os X
     - os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11
       compiler: clang
-      env: COMPILER='clang++'
+      env:
+         - COMPILER='clang++'
+         - MYLDFLAGS='-L/usr/local/opt/llvm/lib'
+         - MYCXXFLAGS='-I/usr/local/opt/llvm/include'
+         - MYPATH='/usr/local/opt/llvm/bin'
 
 
 addons:
   homebrew:
     packages:
     - lcov
+    - llvm
     update: true
   apt:
+    sources:
+    - sourceline: 'ppa:ubuntu-toolchain-r/test'
     packages:
     - lcov
+    - g++-9
     update: true
 
 before_install:
+  - export PATH="${MYPATH}:$PATH"
   - export CXX=${COMPILER}
+  - export LDFLAGS=${MYLDFLAGS}
+  - export CXXFLAGS=${MYCXXFLAGS}
   - git submodule update --init
 
 install:
-  - cmake . -BRelease -DCMAKE_BUILD_TYPE=Release
-  - cmake . -BDebug -DCMAKE_BUILD_TYPE=Debug
+  - cmake -E env LDFLAGS="$LDFLAGS" CXXFLAGS="$CXXFLAGS" cmake . -BRelease -DCMAKE_BUILD_TYPE=Release
+  - cmake -E env LDFLAGS="$LDFLAGS" CXXFLAGS="$CXXFLAGS" cmake . -BDebug -DCMAKE_BUILD_TYPE=Debug
 
 script:
   - cd Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 
 project("lua-formatter" VERSION 1.3.0 LANGUAGES CXX)
 
@@ -9,6 +9,16 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(CheckIPOSupported)
+check_ipo_supported(RESULT lto OUTPUT error)
+
+if(lto)
+   message(STATUS "IPO / LTO enabled")
+   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+   message(STATUS "IPO / LTO not supported: <${error}>")
+endif()
+
 if(NOT CMAKE_BUILD_TYPE)
   message("set build type to Release.")
   set(CMAKE_BUILD_TYPE Release)
@@ -16,8 +26,6 @@ endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
-
-cmake_policy(SET CMP0067 NEW)
 
 try_run(TEST_RUN_RESULT
    TEST_COMPILE_RESULT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 
 project("lua-formatter" VERSION 1.3.0 LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ chop_down_kv_table: true
 table_sep: ","
 extra_sep_at_table_end: false
 break_after_operator: true
+double_quote_to_single_quote: false
+single_quote_to_double_quote: false
 ```
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ luarocks install --server=https://luarocks.org/dev luaformatter
 ### Build from source
 
 #### Requirements
-* cmake 3.8+
+* cmake 3.9+
 * c++ 17 compiler
 
 #### Steps

--- a/docs/Style-Config.md
+++ b/docs/Style-Config.md
@@ -356,4 +356,46 @@ x = 11111 + 11111
     + 11111
 ```
 
+### single_quote_to_double_quote
 
+type: bool, default: false
+
+Transform string literals to use double quote.
+
+```lua
+-- original
+local foo = 'a'
+local foo = '"'
+local bar = 'don\'t'
+local foo = '\''
+local foobar = '\\\\\''
+
+-- transformed
+local foo = "a"
+local foo = "\""
+local bar = "don't"
+local foo = "'"
+local foo = "\\\\'"
+```
+
+### double_quote_to_single_quote
+
+type: bool, default: false
+
+Transform string literals to use single quote.
+
+```lua
+-- original
+local foo = "a"
+local foo = "'"
+local bar = "don't"
+local bar = "\""
+local foobar = "\\\\\""
+
+-- transformed
+local foo = 'a'
+local foo = '\''
+local bar = 'don\'t'
+local bar = '"'
+local foobar = '\\\\"'
+```

--- a/luaformatter-scm-1.rockspec
+++ b/luaformatter-scm-1.rockspec
@@ -1,7 +1,8 @@
+rockspec_format = "3.0"
 package = "LuaFormatter"
 version = "scm-1"
 source = {
-   url = "git+https://github.com/Koihik/LuaFormatter.git"
+   url = "git://github.com/Koihik/LuaFormatter.git"
 }
 description = {
    summary = "Reformats your Lua source code.",

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,6 +1,11 @@
 #include "Config.h"
 
 #include <fstream>
+#include <iostream>
+#include <filesystem>
+#include <cstdlib>
+
+namespace fs = filesystem;
 
 Config::Config() {
     // Defaul configuration
@@ -29,9 +34,25 @@ Config::Config() {
     node_["extra_sep_at_table_end"] = false;
 
     node_["break_after_operator"] = true;
+
+    node_["double_quote_to_single_quote"] = false;
+    node_["single_quote_to_double_quote"] = false;
 }
 
 void Config::readFromFile(const string& file) {
+   fs::file_status status = fs::status(file);
+   fs::perms perm = status.permissions();
+
+   if (!fs::is_regular_file(status)) {
+      cerr << file << ": Not a file." << endl;
+      exit(-1);
+   }
+
+   if ((perm & fs::perms::owner_read) == fs::perms::none) {
+      cerr << file << ": No access to read." << endl;
+      exit(-1);
+   }
+
     YAML::Node n = YAML::LoadFile(file);
 
     // Keys are always strings
@@ -43,6 +64,6 @@ void Config::readFromFile(const string& file) {
     }
 }
 
-void Config::dumpCurrent(ofstream& fout) { fout << node_; }
+void Config::dumpCurrent(ofstream& fout) { fout << node_ << endl; }
 
-void Config::dumpCurrent(ostream& out) { out << node_; }
+void Config::dumpCurrent(ostream& out) { out << node_ << endl; }

--- a/src/FormatVisitor.h
+++ b/src/FormatVisitor.h
@@ -38,6 +38,7 @@ class FormatVisitor : public LuaBaseVisitor {
     antlrcpp::Any visitExplist(LuaParser::ExplistContext* context) override;
 
     antlrcpp::Any visitExp(LuaParser::ExpContext* context) override;
+    antlrcpp::Any visitString(LuaParser::StringContext *ctx) override;
     antlrcpp::Any visitPrefixexp(LuaParser::PrefixexpContext* context) override;
     antlrcpp::Any visitVarOrExp(LuaParser::VarOrExpContext* context) override;
     antlrcpp::Any visitVar(LuaParser::VarContext* context) override;

--- a/src/lua-format.cpp
+++ b/src/lua-format.cpp
@@ -6,10 +6,10 @@
 using namespace std;
 using namespace antlr4;
 
-string __format(ANTLRInputStream& input, const Config& config) {
+static string __format(ANTLRInputStream& input, const Config& config) {
     LuaLexer lexer(&input);
-    CommonTokenStream tokens(&lexer);
-    LuaParser parser(&tokens);
+    CommonTokenStream tokenstream(&lexer);
+    LuaParser parser(&tokenstream);
 
     LuaParser::ChunkContext* chunk = parser.chunk();
 
@@ -18,7 +18,7 @@ string __format(ANTLRInputStream& input, const Config& config) {
     }
 
     vector<antlr4::Token*> tokenVector;
-    for (auto t : tokens.getTokens()) {
+    for (auto t : tokenstream.getTokens()) {
         tokenVector.emplace_back(t);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,19 +56,6 @@ int main(int argc, const char* argv[]) {
     }
 
     if (fs::exists(configFileName)) {
-        fs::file_status status = fs::status(configFileName);
-        fs::perms perm = status.permissions();
-
-        if (!fs::is_regular_file(status)) {
-            cerr << configFileName << ": Not a file." << endl;
-            return -1;
-        }
-
-        if ((perm & fs::perms::owner_read) == fs::perms::none) {
-            cerr << configFileName << ": No access to read." << endl;
-            return -1;
-        }
-
         // Keeps the default values in case the yaml is missing a field
         config.readFromFile(configFileName);
     } else {

--- a/test/test_format_file.cpp
+++ b/test/test_format_file.cpp
@@ -1,5 +1,4 @@
-#include <sys/stat.h>
-
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -10,6 +9,7 @@
 #include "lua-format.h"
 
 using namespace std;
+namespace fs = filesystem;
 
 #define TEST_FILE(file)                                                                                     \
     TEST_CASE("format file " + string(file) + " works well", "format_file") {                               \
@@ -21,19 +21,18 @@ using namespace std;
         string expectFileName = filename.substr(0, idx) + "/_" + filename.substr(idx + 1, filename.size()); \
         idx = filename.find_last_of('.');                                                                   \
         string configFileName = filename.substr(0, idx) + ".config";                                        \
-        struct stat s;                                                                                      \
-        if (stat(configFileName.c_str(), &s) == 0) {                                                        \
+        if (fs::exists(configFileName)) {                                                                   \
             std::cout << configFileName << " exist" << endl;                                                \
             config.readFromFile(configFileName);                                                            \
             std::cout << config.get<bool>("chop_down_parameter") << " dd" << endl;                          \
         }                                                                                                   \
-        string actul = lua_format(input, config);                                                           \
+        string actual = lua_format(input, config);                                                          \
         ifstream expectFile(expectFileName);                                                                \
         stringstream ss;                                                                                    \
         ss << expectFile.rdbuf();                                                                           \
         string expect = ss.str();                                                                           \
-        REQUIRE(expect == actul);                                                                           \
-        string formatTwice = lua_format(actul, config);                                                     \
+        REQUIRE(expect == actual);                                                                          \
+        string formatTwice = lua_format(actual, config);                                                    \
         REQUIRE(expect == formatTwice);                                                                     \
     }
 
@@ -62,6 +61,9 @@ TEST_FILE("../test/testdata/statement/semi.lua");
 TEST_FILE("../test/testdata/statement/shebang.lua");
 TEST_FILE("../test/testdata/statement/statements.lua");
 TEST_FILE("../test/testdata/statement/table.lua");
+
+TEST_FILE("../test/testdata/literals/doublequote.lua");
+TEST_FILE("../test/testdata/literals/singlequote.lua");
 
 TEST_FILE("../test/testdata/syntax/lua54.lua");
 

--- a/test/testdata/literals/_doublequote.lua
+++ b/test/testdata/literals/_doublequote.lua
@@ -1,0 +1,5 @@
+local foo = 'a'
+local foo = '\''
+local bar = 'don\'t'
+local bar = '"'
+local foobar = '\\\\"'

--- a/test/testdata/literals/_singlequote.lua
+++ b/test/testdata/literals/_singlequote.lua
@@ -1,0 +1,5 @@
+local foo = "a"
+local foo = "\""
+local bar = "don't"
+local foo = "'"
+local foobar = "\\\\'"

--- a/test/testdata/literals/doublequote.config
+++ b/test/testdata/literals/doublequote.config
@@ -1,0 +1,1 @@
+double_quote_to_single_quote: true

--- a/test/testdata/literals/doublequote.lua
+++ b/test/testdata/literals/doublequote.lua
@@ -1,0 +1,5 @@
+local foo = "a"
+local foo = "'"
+local bar = "don't"
+local bar = "\""
+local foobar = "\\\\\""

--- a/test/testdata/literals/singlequote.config
+++ b/test/testdata/literals/singlequote.config
@@ -1,0 +1,1 @@
+single_quote_to_double_quote: true

--- a/test/testdata/literals/singlequote.lua
+++ b/test/testdata/literals/singlequote.lua
@@ -1,0 +1,5 @@
+local foo = 'a'
+local foo = '"'
+local bar = 'don\'t'
+local foo = '\''
+local foobar = '\\\\\''


### PR DESCRIPTION
now it's possible to specify string literals preference
for example:
   local foo = "a" <-> local foo = 'a'
   local foo = 'don\'t' <-> local foo = "don't"