### PR TITLE
fix: don't use relative paths on tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ if(BUILD_TESTS)
       )
   endif()
 
+  target_compile_definitions(lua-format-test PUBLIC PROJECT_PATH="${PROJECT_SOURCE_DIR}")
   target_link_libraries(lua-format-test yaml-cpp antlr4-cpp-runtime)
 
   add_test(all_tests lua-format-test)

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -166,13 +166,13 @@ TEST_CASE("break_after_operator", "config") {
 
 TEST_CASE("read from file", "config") {
     Config config;
-    config.readFromFile("../test/testconfig/1.lua-format");
+    config.readFromFile(PROJECT_PATH "/test/testconfig/1.lua-format");
 
     REQUIRE(2 == config.get<int>("indent_width"));
     REQUIRE(";" == config.get<string>("table_sep"));
     REQUIRE(false == config.get<bool>("extra_sep_at_table_end"));
 
-    config.readFromFile("../test/testconfig/2.lua-format");
+    config.readFromFile(PROJECT_PATH "/test/testconfig/2.lua-format");
 
     REQUIRE(4 == config.get<int>("indent_width"));
     REQUIRE("," == config.get<string>("table_sep"));

--- a/test/test_format_file.cpp
+++ b/test/test_format_file.cpp
@@ -36,45 +36,45 @@ namespace fs = filesystem;
         REQUIRE(expect == formatTwice);                                                                     \
     }
 
-TEST_FILE("../test/testdata/linebreak/args_length.lua");
-TEST_FILE("../test/testdata/linebreak/block.lua");
-TEST_FILE("../test/testdata/linebreak/chained_call_args.lua");
-TEST_FILE("../test/testdata/linebreak/disable_align_in_function.lua");
-TEST_FILE("../test/testdata/linebreak/functioncall.lua");
-TEST_FILE("../test/testdata/linebreak/functiondef.lua");
-TEST_FILE("../test/testdata/linebreak/indent_in_explist.lua");
-TEST_FILE("../test/testdata/linebreak/long_var.lua");
-TEST_FILE("../test/testdata/linebreak/nested_method_call.lua");
-TEST_FILE("../test/testdata/linebreak/operators.lua");
-TEST_FILE("../test/testdata/linebreak/table.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/args_length.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/block.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/chained_call_args.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/disable_align_in_function.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/functioncall.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/functiondef.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/indent_in_explist.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/long_var.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/nested_method_call.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/operators.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/linebreak/table.lua");
 
-TEST_FILE("../test/testdata/comment/function.lua");
-TEST_FILE("../test/testdata/comment/space.lua");
-TEST_FILE("../test/testdata/comment/table.lua");
-TEST_FILE("../test/testdata/comment/varlist.lua");
-TEST_FILE("../test/testdata/comment/attrib.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/comment/function.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/comment/space.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/comment/table.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/comment/varlist.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/comment/attrib.lua");
 
-TEST_FILE("../test/testdata/statement/function_call.lua");
-TEST_FILE("../test/testdata/statement/function.lua");
-TEST_FILE("../test/testdata/statement/operator.lua");
-TEST_FILE("../test/testdata/statement/semi.lua");
-TEST_FILE("../test/testdata/statement/shebang.lua");
-TEST_FILE("../test/testdata/statement/statements.lua");
-TEST_FILE("../test/testdata/statement/table.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/statement/function_call.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/statement/function.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/statement/operator.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/statement/semi.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/statement/shebang.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/statement/statements.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/statement/table.lua");
 
-TEST_FILE("../test/testdata/literals/doublequote.lua");
-TEST_FILE("../test/testdata/literals/singlequote.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/literals/doublequote.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/literals/singlequote.lua");
 
-TEST_FILE("../test/testdata/syntax/lua54.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/syntax/lua54.lua");
 
-TEST_FILE("../test/testdata/expression/function_1.lua");
-TEST_FILE("../test/testdata/expression/function_2.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/expression/function_1.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/expression/function_2.lua");
 
-TEST_FILE("../test/testdata/issues/issue-1.lua");
-TEST_FILE("../test/testdata/issues/issue-18.lua");
-TEST_FILE("../test/testdata/issues/issue-19.lua");
-TEST_FILE("../test/testdata/issues/issue-36.lua");
-TEST_FILE("../test/testdata/issues/issue-62_1.lua");
-TEST_FILE("../test/testdata/issues/issue-62_2.lua");
-TEST_FILE("../test/testdata/issues/issue-62_3.lua");
-TEST_FILE("../test/testdata/issues/issue-70.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-1.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-18.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-19.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-36.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_1.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_2.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_3.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-70.lua");

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -20,4 +20,4 @@ namespace fs = filesystem;
         REQUIRE_THROWS_WITH(lua_format(input, config), "Input contains syntax errors");                     \
     }
 
-TEST_FILE("../test/testdata/issues/issue-55.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-55.lua");


### PR DESCRIPTION
Removed the use of relative paths on testing. Discussed in #63.

Signed-off-by: Pedro Tammela <pctammela@gmail.com>