### PR TITLE
Support "disable_simple_one_line_block" for specific type of code block.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ use_tab: false
 tab_width: 4
 continuation_indent_width: 4
 spaces_before_call: 1
-keep_simple_block_one_line: true
+keep_simple_control_block_one_line: true
+keep_simple_function_one_line: true
 align_args: true
 break_after_functioncall_lp: false
 break_before_functioncall_rp: false

--- a/docs/Style-Config.md
+++ b/docs/Style-Config.md
@@ -74,26 +74,37 @@ local xxx, yyy =
     111, 222
 ```
 
-### keep_simple_block_one_line
+### keep_simple_control_block_one_line
 
 type: bool, default: true
 
-Allow format simple block to one line.
+Allow format simple control block(e.g. if, while, for, ...) to one line.
 
 ```lua
 -- keep_simple_block_one_line: true
-function x() print(1) end
 if cond then xx() end
 
 -- keep_simple_block_one_line: false
-function x()
-    print(1)
-end
 if cond then
     xx()
 end
 ```
 
+### keep_simple_function_one_line
+
+type: bool, default: true
+
+Allow format simple function to one line.
+
+```lua
+-- keep_simple_block_one_line: true
+function x() print(1) end
+
+-- keep_simple_block_one_line: false
+function x()
+    print(1)
+end
+```
 ### align_args
 
 type: bool, default: true

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -16,7 +16,8 @@ Config::Config() {
     node_["continuation_indent_width"] = 4;
     node_["spaces_before_call"] = 1;
 
-    node_["keep_simple_block_one_line"] = true;
+    node_["keep_simple_control_block_one_line"] = true;
+    node_["keep_simple_function_one_line"] = true;
 
     node_["align_args"] = true;
     node_["break_after_functioncall_lp"] = false;

--- a/src/FormatVisitor.h
+++ b/src/FormatVisitor.h
@@ -8,6 +8,8 @@
 using namespace std;
 using namespace antlr4;
 
+
+enum BlockType { CONTROL_BLOCK, FUNCTION_BLOCK };
 enum NewLineIndent { NONE_INDENT, INC_INDENT, DEC_INDENT, INC_CONTINUATION_INDENT, DEC_CONTINUATION_INDENT };
 
 class FormatVisitor : public LuaBaseVisitor {
@@ -21,7 +23,7 @@ class FormatVisitor : public LuaBaseVisitor {
     antlrcpp::Any visitVarDecl(LuaParser::VarDeclContext* context) override;
     antlrcpp::Any visitGotoStat(LuaParser::GotoStatContext* context) override;
     antlrcpp::Any visitDoStat(LuaParser::DoStatContext* context) override;
-    antlrcpp::Any visitWhileStat(LuaParser::WhileStatContext* context) override;
+    antlrcpp::Any visitWhileStat(LuaParser::WhileStatContext* context) override; 
     antlrcpp::Any visitRepeatStat(LuaParser::RepeatStatContext* context) override;
     antlrcpp::Any visitIfStat(LuaParser::IfStatContext* context) override;
     antlrcpp::Any visitForStat(LuaParser::ForStatContext* context) override;
@@ -80,9 +82,9 @@ class FormatVisitor : public LuaBaseVisitor {
 
     string formatLineComment(Token* token);
 
-    bool needKeepBlockOneLine(tree::ParseTree* previousNode, LuaParser::BlockContext* ctx);
+    bool needKeepBlockOneLine(tree::ParseTree* previousNode, LuaParser::BlockContext* ctx, BlockType blockType);
     bool isBlockEmpty(LuaParser::BlockContext* ctx);
-    void visitBlockAndComment(tree::ParseTree* previousNode, LuaParser::BlockContext* ctx);
+    void visitBlockAndComment(tree::ParseTree* previousNode, LuaParser::BlockContext* ctx, BlockType blockType);
     void visitNextNameAndArgs(LuaParser::VarSuffixContext* ctx);
 
     void pushWriter();

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -58,13 +58,13 @@ TEST_CASE("extra_sep_at_table_end", "config") {
     REQUIRE("x = {\n  1, -- line break\n  2, 3\n}\n" == lua_format("x = {1,-- line break\n2;3}", config));
 }
 
-TEST_CASE("keep_simple_block_one_line", "config") {
+TEST_CASE("keep_simple_function_one_line", "config") {
     Config config;
     config.set("indent_width", 2);
 
     REQUIRE("function x() print(1) end\n" == lua_format("function x() print(1) end", config));
 
-    config.set("keep_simple_block_one_line", false);
+    config.set("keep_simple_function_one_line", false);
     REQUIRE("function x()\n  print(1)\nend\n" == lua_format("function x() print(1) end", config));
 }
 

--- a/test/test_format_file.cpp
+++ b/test/test_format_file.cpp
@@ -78,3 +78,8 @@ TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_1.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_2.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_3.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-70.lua");
+
+TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/default.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/keep_simple_function_one_line_false.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/keep_simple_control_block_one_line_false.lua");
+

--- a/test/testdata/issues/issue-36.config
+++ b/test/testdata/issues/issue-36.config
@@ -2,7 +2,8 @@ column_limit: 120
 indent_width: 4
 continuation_indent_width: 4
 use_tab: false
-keep_simple_block_one_line: false
+keep_simple_control_block_one_line: false
+keep_simple_function_one_line: false
 align_args: true
 break_after_functioncall_lp: true
 break_before_functioncall_rp: true

--- a/test/testdata/keep_simple_block_one_line/_default.lua
+++ b/test/testdata/keep_simple_block_one_line/_default.lua
@@ -1,0 +1,41 @@
+function x() print("hello") end
+
+function x() print("hello") end
+
+local function x() print("hello") end
+
+local function x() print("hello") end
+
+x = function() print("hello") end
+
+x = function() print("hello") end
+
+if true then print("hello") end
+
+if true then
+    print("hello")
+elseif true then
+    print("hello")
+end
+
+if true then print("hello") end
+
+while true do print("hello") end
+
+while true do print("hello") end
+
+repeat print("hello") until true
+
+repeat print("hello") until true
+
+do print("hello") end
+
+do print("hello") end
+
+for _ = 1, 10, 1 do print("hello") end
+
+for _ = 1, 10, 1 do print("hello") end
+
+for _ in pairs({}) do print("hello") end
+
+for _ in pairs({}) do print("hello") end

--- a/test/testdata/keep_simple_block_one_line/_keep_simple_control_block_one_line_false.lua
+++ b/test/testdata/keep_simple_block_one_line/_keep_simple_control_block_one_line_false.lua
@@ -1,0 +1,65 @@
+function x() print("hello") end
+
+function x() print("hello") end
+
+local function x() print("hello") end
+
+local function x() print("hello") end
+
+x = function() print("hello") end
+
+x = function() print("hello") end
+
+if true then
+    print("hello")
+end
+
+if true then
+    print("hello")
+elseif true then
+    print("hello")
+end
+
+if true then
+    print("hello")
+end
+
+while true do
+    print("hello")
+end
+
+while true do
+    print("hello")
+end
+
+repeat
+    print("hello")
+until true
+
+repeat
+    print("hello")
+until true
+
+do
+    print("hello")
+end
+
+do
+    print("hello")
+end
+
+for _ = 1, 10, 1 do
+    print("hello")
+end
+
+for _ = 1, 10, 1 do
+    print("hello")
+end
+
+for _ in pairs({}) do
+    print("hello")
+end
+
+for _ in pairs({}) do
+    print("hello")
+end

--- a/test/testdata/keep_simple_block_one_line/_keep_simple_function_one_line_false.lua
+++ b/test/testdata/keep_simple_block_one_line/_keep_simple_function_one_line_false.lua
@@ -1,0 +1,53 @@
+function x()
+    print("hello")
+end
+
+function x()
+    print("hello")
+end
+
+local function x()
+    print("hello")
+end
+
+local function x()
+    print("hello")
+end
+
+x = function()
+    print("hello")
+end
+
+x = function()
+    print("hello")
+end
+
+if true then print("hello") end
+
+if true then
+    print("hello")
+elseif true then
+    print("hello")
+end
+
+if true then print("hello") end
+
+while true do print("hello") end
+
+while true do print("hello") end
+
+repeat print("hello") until true
+
+repeat print("hello") until true
+
+do print("hello") end
+
+do print("hello") end
+
+for _ = 1, 10, 1 do print("hello") end
+
+for _ = 1, 10, 1 do print("hello") end
+
+for _ in pairs({}) do print("hello") end
+
+for _ in pairs({}) do print("hello") end

--- a/test/testdata/keep_simple_block_one_line/default.lua
+++ b/test/testdata/keep_simple_block_one_line/default.lua
@@ -1,0 +1,59 @@
+function x()
+    print("hello")
+end
+
+function x() print("hello") end
+
+local function x()
+    print("hello")
+end
+
+local function x() print("hello") end
+
+x = function()
+    print("hello")
+end
+
+x = function() print("hello") end
+
+if true then
+    print("hello")
+end
+
+if true then
+    print("hello")
+elseif true then
+    print("hello")
+end
+
+if true then print("hello") end
+
+while true do
+    print("hello")
+end
+
+while true do print("hello") end
+
+repeat
+    print("hello")
+until true
+
+repeat print("hello") until true
+
+do
+    print("hello")
+end
+
+do print("hello") end
+
+for _ = 1, 10, 1 do
+    print("hello")
+end
+
+for _ = 1, 10, 1 do print("hello") end
+
+for _ in pairs({}) do
+    print("hello")
+end
+
+for _ in pairs({}) do print("hello") end

--- a/test/testdata/keep_simple_block_one_line/keep_simple_control_block_one_line_false.config
+++ b/test/testdata/keep_simple_block_one_line/keep_simple_control_block_one_line_false.config
@@ -1,0 +1,1 @@
+keep_simple_control_block_one_line: false

--- a/test/testdata/keep_simple_block_one_line/keep_simple_control_block_one_line_false.lua
+++ b/test/testdata/keep_simple_block_one_line/keep_simple_control_block_one_line_false.lua
@@ -1,0 +1,59 @@
+function x()
+    print("hello")
+end
+
+function x() print("hello") end
+
+local function x()
+    print("hello")
+end
+
+local function x() print("hello") end
+
+x = function()
+    print("hello")
+end
+
+x = function() print("hello") end
+
+if true then
+    print("hello")
+end
+
+if true then
+    print("hello")
+elseif true then
+    print("hello")
+end
+
+if true then print("hello") end
+
+while true do
+    print("hello")
+end
+
+while true do print("hello") end
+
+repeat
+    print("hello")
+until true
+
+repeat print("hello") until true
+
+do
+    print("hello")
+end
+
+do print("hello") end
+
+for _ = 1, 10, 1 do
+    print("hello")
+end
+
+for _ = 1, 10, 1 do print("hello") end
+
+for _ in pairs({}) do
+    print("hello")
+end
+
+for _ in pairs({}) do print("hello") end

--- a/test/testdata/keep_simple_block_one_line/keep_simple_function_one_line_false.config
+++ b/test/testdata/keep_simple_block_one_line/keep_simple_function_one_line_false.config
@@ -1,0 +1,1 @@
+keep_simple_function_one_line: false

--- a/test/testdata/keep_simple_block_one_line/keep_simple_function_one_line_false.lua
+++ b/test/testdata/keep_simple_block_one_line/keep_simple_function_one_line_false.lua
@@ -1,0 +1,59 @@
+function x()
+    print("hello")
+end
+
+function x() print("hello") end
+
+local function x()
+    print("hello")
+end
+
+local function x() print("hello") end
+
+x = function()
+    print("hello")
+end
+
+x = function() print("hello") end
+
+if true then
+    print("hello")
+end
+
+if true then
+    print("hello")
+elseif true then
+    print("hello")
+end
+
+if true then print("hello") end
+
+while true do
+    print("hello")
+end
+
+while true do print("hello") end
+
+repeat
+    print("hello")
+until true
+
+repeat print("hello") until true
+
+do
+    print("hello")
+end
+
+do print("hello") end
+
+for _ = 1, 10, 1 do
+    print("hello")
+end
+
+for _ = 1, 10, 1 do print("hello") end
+
+for _ in pairs({}) do
+    print("hello")
+end
+
+for _ in pairs({}) do print("hello") end


### PR DESCRIPTION
### Summary
* More granular control over "keep_simple_block_one_line".
* This should be backward compatible. 
* Note, I haven't updated README.md or other docs yet; I will do that once I get approval for this change. 

Thank you!
