### PR TITLE
add support clang compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
   set(extra-libs "stdc++fs")
 else()
   set(extra-libs "")


### PR DESCRIPTION
Before create configuration cmake script try compile some program which required `filesystem` from 17 standard. `gcc` and `clang` required manually linking `stdc++fs` library, but in `CMakeLists.txt` the library appends only for `gcc`. So I fix that