### PR TITLE
fix bug with wrong indendation in fucntion call

### DIFF
--- a/test/test_format_file.cpp
+++ b/test/test_format_file.cpp
@@ -1,3 +1,4 @@
+#include <catch2/catch.hpp>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -5,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include <catch2/catch.hpp>
 #include "lua-format.h"
 
 using namespace std;
@@ -79,8 +79,8 @@ TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_2.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_3.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-70.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-80.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/PR-100.lua");
 
 TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/default.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/keep_simple_function_one_line_false.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/keep_simple_control_block_one_line_false.lua");
-

--- a/test/testdata/issues/PR-100.config
+++ b/test/testdata/issues/PR-100.config
@@ -1,0 +1,8 @@
+column_limit: 80
+indent_width: 2
+continuation_indent_width: 2
+
+align_parameter: false
+
+break_before_functioncall_rp: true
+break_after_functioncall_lp: true

--- a/test/testdata/issues/PR-100.lua
+++ b/test/testdata/issues/PR-100.lua
@@ -1,0 +1,1 @@
+local var = function_call( alpha, beta, charlie, delta, echo, gamma, foxtrot, golf, hotel, india, juliet, kilo)

--- a/test/testdata/issues/_PR-100.lua
+++ b/test/testdata/issues/_PR-100.lua
@@ -1,0 +1,4 @@
+local var = function_call(
+  alpha, beta, charlie, delta, echo, gamma, foxtrot, golf, hotel, india, juliet,
+  kilo
+)


### PR DESCRIPTION
Config file

```
column_limit: 120
use_tab: true
indent_width: 1
continuation_indent_width: 1
keep_simple_control_block_one_line: false
keep_simple_function_one_line: false
align_args: false
break_after_functioncall_lp: true
break_before_functioncall_rp: true
break_after_functiondef_lp: true
break_before_functiondef_rp: true
align_parameter: false
align_table_field: false
break_after_table_lb: false
break_before_table_rb: false
chop_down_kv_table: true
chop_down_parameter: true
chop_down_table: false
table_sep: ','
extra_sep_at_table_end: true
break_after_operator: true
single_quote_to_double_quote: false
double_quote_to_single_quote: false
spaces_before_call: 0
```

Input:

```lua
-- @return new occ_token for user
function M:add_permission(admin_token, user_id, occ_token, permission)
	auxilary.assert_type(admin_token, "string")
	auxilary.assert_type(user_id, "string")
	auxilary.assert_type(occ_token, "string")
	auxilary.assert_type(permission, "string")

	local output = self.base:call_request(
               		"POST", "/user/permission/add", {["Content-Type"] = auxilary.mime_types.json, token = admin_token},
               			cjson.encode({user_id = user_id, occ_token = occ_token, permission = permission})
               	)

	local out, err = self.base.check_response_json(output, {"occ_token"})
	if out == nil then
		return nil, err
	end
	return out.occ_token
end
````

So, when I try format this I get output equal to input, BUT! I set `align_parameter: false`, so I expect this as result:

```lua
-- @return new occ_token for user
function M:add_permission(admin_token, user_id, occ_token, permission)
	auxilary.assert_type(admin_token, "string")
	auxilary.assert_type(user_id, "string")
	auxilary.assert_type(occ_token, "string")
	auxilary.assert_type(permission, "string")

	local output = self.base:call_request(
		"POST", "/user/permission/add", {["Content-Type"] = auxilary.mime_types.json, token = admin_token},
			cjson.encode({user_id = user_id, occ_token = occ_token, permission = permission})
	)

	local out, err = self.base.check_response_json(output, {"occ_token"})
	if out == nil then
		return nil, err
	end
	return out.occ_token
end
```

So I fix that problem (add check in `visitPrefixexp` method of `align_parameter` property)