### PR TITLE
fix wrong continuation indent in fucntion arguments

### DIFF
--- a/src/FormatVisitor.cpp
+++ b/src/FormatVisitor.cpp
@@ -697,9 +697,8 @@ antlrcpp::Any FormatVisitor::visitNamelist(LuaParser::NamelistContext* ctx) {
                     cur_writer() << indent();
                     indent_ -= firstParameterIndent;
                 } else {
-                    cur_writer() << commentAfterNewLine(ctx->COMMA()[i], INC_CONTINUATION_INDENT);
+                    cur_writer() << commentAfterNewLine(ctx->COMMA()[i], NONE_INDENT);
                     cur_writer() << indent();
-                    hasIncIndent = true;
                 }
             }
             cur_writer() << ctx->NAME()[i + 1]->getText();
@@ -906,9 +905,8 @@ antlrcpp::Any FormatVisitor::visitExplist(LuaParser::ExplistContext* ctx) {
                     cur_writer() << indentWithAlign();
                     hasIncIndentForAlign = true;
                 } else {
-                    cur_writer() << commentAfterNewLine(ctx->COMMA()[i], INC_CONTINUATION_INDENT);
+                    cur_writer() << commentAfterNewLine(ctx->COMMA()[i], NONE_INDENT);
                     cur_writer() << indentWithAlign();
-                    hasIncIndent = true;
                 }
             }
             visitExp(ctx->exp()[i + 1]);
@@ -1062,9 +1060,8 @@ antlrcpp::Any FormatVisitor::visitString(LuaParser::StringContext* ctx) {
         *newstr.rbegin() = quote;
 
         // undo a transformation that invalidates strings in certain conditions
-        if (newstr.at(newstr.size() - 2) == '\\' &&
-              newstr.at(newstr.size() - 3) != '\\')
-           newstr.insert(newstr.size() - 2, "\\");
+        if (newstr.at(newstr.size() - 2) == '\\' && newstr.at(newstr.size() - 3) != '\\')
+            newstr.insert(newstr.size() - 2, "\\");
 
         cur_writer() << newstr;
         return nullptr;
@@ -1481,8 +1478,7 @@ antlrcpp::Any FormatVisitor::visitTableconstructor(LuaParser::TableconstructorCo
         bool breakAfterLb = false;
         if (beyondLimit) {
             breakAfterLb = config_.get<bool>("break_after_table_lb");
-            chopDown = config_.get<bool>("chop_down_table") ||
-				(config_.get<bool>("chop_down_kv_table") && containsKv);
+            chopDown = config_.get<bool>("chop_down_table") || (config_.get<bool>("chop_down_kv_table") && containsKv);
         }
         if (chopDown) {
             cur_writer() << commentAfterNewLine(ctx->LB(), INC_INDENT);
@@ -1652,10 +1648,11 @@ antlrcpp::Any FormatVisitor::visitTerminal(tree::TerminalNode* node) {
     return nullptr;
 }
 
-bool FormatVisitor::needKeepBlockOneLine(tree::ParseTree* previousNode, LuaParser::BlockContext* ctx, BlockType blockType) {
-    if (blockType == CONTROL_BLOCK && !config_.get<bool>("keep_simple_control_block_one_line")){
+bool FormatVisitor::needKeepBlockOneLine(tree::ParseTree* previousNode, LuaParser::BlockContext* ctx,
+                                         BlockType blockType) {
+    if (blockType == CONTROL_BLOCK && !config_.get<bool>("keep_simple_control_block_one_line")) {
         return false;
-    } else if(blockType == FUNCTION_BLOCK && !config_.get<bool>("keep_simple_function_one_line")){
+    } else if (blockType == FUNCTION_BLOCK && !config_.get<bool>("keep_simple_function_one_line")) {
         return false;
     }
 
@@ -1698,7 +1695,8 @@ bool FormatVisitor::isBlockEmpty(LuaParser::BlockContext* ctx) {
     return ctx->stat().size() == 0 && ctx->retstat() == NULL;
 }
 
-void FormatVisitor::visitBlockAndComment(tree::ParseTree* previousNode, LuaParser::BlockContext* ctx, BlockType blockType) {
+void FormatVisitor::visitBlockAndComment(tree::ParseTree* previousNode, LuaParser::BlockContext* ctx,
+                                         BlockType blockType) {
     LOG_FUNCTION_BEGIN();
     bool oneline = needKeepBlockOneLine(previousNode, ctx, blockType);
     if (oneline) {


### PR DESCRIPTION
Config

```
column_limit: 120
use_tab: true
indent_width: 1
continuation_indent_width: 4
keep_simple_control_block_one_line: false
keep_simple_function_one_line: false
align_args: false
break_after_functioncall_lp: true
break_before_functioncall_rp: true
break_after_functiondef_lp: true
break_before_functiondef_rp: true
align_parameter: false
align_table_field: false
break_after_table_lb: false
break_before_table_rb: false
chop_down_kv_table: true
chop_down_parameter: true
chop_down_table: false
table_sep: ','
extra_sep_at_table_end: true
break_after_operator: true
single_quote_to_double_quote: false
double_quote_to_single_quote: false
spaces_before_call: 0
```

Input

```lua
-- @return new occ_token for user
function M:add_permission(
				admin_token,
								user_id,
								occ_token,
								permission,
								aksdgkajgk,
								aghadkfjgadfjgk,
								akhfjdkahjkadfj,
								akhjdfkajh,
								kasfjdgkadjgfk,
								akgjfdkajg
)
	auxilary.assert_type(admin_token, "string")
	auxilary.assert_type(user_id, "string")
	auxilary.assert_type(occ_token, "string")
	auxilary.assert_type(permission, "string")

	local output = self.base:call_request(
               					"POST", "/user/permission/add", {["Content-Type"] = auxilary.mime_types.json, token = admin_token},
               									cjson.encode({user_id = user_id, occ_token = occ_token, permission = permission})
               	)

	local out, err = self.base.check_response_json(output, {"occ_token"})
	if out == nil then
		return nil, err
	end
	return out.occ_token
end
```

When I try format the input I expected get same result:

```lua
-- @return new occ_token for user
function M:add_permission(
				admin_token,
				user_id,
				occ_token,
				permission,
				aksdgkajgk,
				aghadkfjgadfjgk,
				akhfjdkahjkadfj,
				akhjdfkajh,
				kasfjdgkadjgfk,
				akgjfdkajg
)
	auxilary.assert_type(admin_token, "string")
	auxilary.assert_type(user_id, "string")
	auxilary.assert_type(occ_token, "string")
	auxilary.assert_type(permission, "string")

	local output = self.base:call_request(
               					"POST", "/user/permission/add", {["Content-Type"] = auxilary.mime_types.json, token = admin_token},
               					cjson.encode({user_id = user_id, occ_token = occ_token, permission = permission})
               	)

	local out, err = self.base.check_response_json(output, {"occ_token"})
	if out == nil then
		return nil, err
	end
	return out.occ_token
end
```

But it don't happens. I get output without any difference of input. Here is wrong continuous intendation in function defenition and function call. So I fix that