### PR TITLE
fix issue#98 : adding column_table_limit feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ break_before_table_rb: true
 chop_down_table: false
 chop_down_kv_table: true
 table_sep: ","
+column_table_limit: column_limit
 extra_sep_at_table_end: false
 break_after_operator: true
 double_quote_to_single_quote: false

--- a/docs/Style-Config.md
+++ b/docs/Style-Config.md
@@ -325,6 +325,48 @@ x = {
     k3 = v3, k4 = v4
 }
 ```
+### column_table_limit
+
+type: int, default: column_limit
+
+The column limit of each line of a table. Default value the same as column_limit value.
+
+```lua
+--column_table_limit: column_limit
+test = {
+  image = "test",
+  list = {
+    {
+      ref = "testRef",
+      tags = {"tagTest"},
+      time = 10,
+
+      materials = {{materialId = 123, count = 10}}
+    }
+  }
+}
+
+--column_table_limit: 20
+test = {
+  image = "test",
+  list = {
+    {
+      ref = "testRef",
+      tags = {
+        "tagTest"
+      },
+      time = 10,
+
+      materials = {
+        {
+          materialId = 123,
+          count = 10
+        }
+      }
+    }
+  }
+}
+```
 
 ### table_sep
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -35,6 +35,7 @@ Config::Config() {
     node_["chop_down_kv_table"] = true;
     node_["table_sep"] = ",";
     node_["extra_sep_at_table_end"] = false;
+    node_["column_table_limit"] = node_["column_limit"];
 
     node_["break_after_operator"] = true;
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -60,11 +60,20 @@ void Config::readFromFile(const string& file) {
     YAML::Node n = YAML::LoadFile(file);
 
     // Keys are always strings
+    bool given = false;
+    string CTL = "column_table_limit";
+    string CL = "column_limit";
     for (auto kv : n) {
         auto key = kv.first.as<string>();
         if (node_[key]) {
             node_[key] = kv.second;
         }
+        if (key == CTL) {
+            given = true;
+        }
+    }
+    if (!given) {
+        node_[CTL] = node_[CL];
     }
 }
 

--- a/src/FormatVisitor.cpp
+++ b/src/FormatVisitor.cpp
@@ -1475,7 +1475,7 @@ antlrcpp::Any FormatVisitor::visitTableconstructor(LuaParser::TableconstructorCo
             int length = cur_writer().firstLineColumn();
             int lines = cur_writer().lines();
             popWriter();
-            beyondLimit = cur_columns() + length > config_.get<int>("column_limit") || lines > 1;
+            beyondLimit = cur_columns() + length > config_.get<int>("column_table_limit") || lines > 1;
         }
         bool breakAfterLb = false;
         if (beyondLimit) {
@@ -1570,7 +1570,7 @@ antlrcpp::Any FormatVisitor::visitFieldlist(LuaParser::FieldlistContext* ctx) {
         int length = cur_writer().firstLineColumn();
         popWriter();
         if (i != n - 1 || config_.get<bool>("extra_sep_at_table_end")) length++;  // calc a ',' if exp >1
-        beyondLimit = cur_columns() + length > config_.get<int>("column_limit");
+        beyondLimit = cur_columns() + length > config_.get<int>("column_table_limit");
         if (beyondLimit) {
             if (config_.get<bool>("align_table_field")) {
                 cur_writer() << commentAfterNewLine(ctx->fieldsep()[i - 1], NONE_INDENT);

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -149,6 +149,17 @@ TEST_CASE("table", "config") {
     config.set("break_after_table_lb", false);
     config.set("break_before_table_rb", false);
     REQUIRE("x = {1, 2, 3,\n  4, 5, 6, 7}\n" == lua_format("x = {1,2,3,4,5,6,7}", config));
+
+    config.set("column_limit", 250);
+    config.set("indent_width", 2);
+    config.set("tab_width", 2);
+    config.set("continuation_indent_width", 2);
+    config.set("chop_down_table", true);
+    config.set("chop_down_kv_table", true);
+    config.set("column_table_limit", 80);
+
+    REQUIRE("test = {\n  image = {1, 2, 3},\n  list = {\n    {\n      ref = {4, 5, 9, 8, 2},\n      tags = {1, 2, 8, 6},\n      time = 10,\n\n      materials = {{materialId = 123, count = 10}}\n    }\n  }\n}\n" ==
+            lua_format("test = {\n  image = {1,2,3},\n  list = {\n    {\n      ref = {4,5,9,8,2},\n      tags = { 1, 2, 8, 6 },\n      time = 10,\n\n      materials = {\n        {\n          materialId = 123,\n          count = 10\n        }\n      },\n    },\n  },\n}", config));
 }
 
 TEST_CASE("break_after_operator", "config") {

--- a/test/test_format_file.cpp
+++ b/test/test_format_file.cpp
@@ -78,7 +78,10 @@ TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_1.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_2.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-62_3.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-70.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-98.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-98_1.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-80.lua");
+
 
 TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/default.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/keep_simple_function_one_line_false.lua");

--- a/test/testdata/issues/_issue-98.lua
+++ b/test/testdata/issues/_issue-98.lua
@@ -1,0 +1,12 @@
+test = {
+  image = "test",
+  list = {
+    {
+      ref = "testRef",
+      tags = {"tagTest"},
+      time = 10,
+
+      materials = {{materialId = 123, count = 10}}
+    }
+  }
+}

--- a/test/testdata/issues/_issue-98_1.lua
+++ b/test/testdata/issues/_issue-98_1.lua
@@ -1,0 +1,14 @@
+test = {
+  image = "test",
+  list = {
+    {
+      ref = "testRef",
+      tags = {"tagTest"},
+      time = 10,
+
+      materials = {
+        {materialId = 123, count = 10}
+      }
+    }
+  }
+}

--- a/test/testdata/issues/issue-98.config
+++ b/test/testdata/issues/issue-98.config
@@ -1,0 +1,7 @@
+column_limit: 250
+indent_width: 2
+tab_width: 2
+continuation_indent_width: 2
+chop_down_table: true
+chop_down_kv_table: true
+column_table_limit: 80

--- a/test/testdata/issues/issue-98.lua
+++ b/test/testdata/issues/issue-98.lua
@@ -1,0 +1,17 @@
+test = {
+  image = "test",
+  list = {
+    {
+      ref = "testRef",
+      tags = { "tagTest" },
+      time = 10,
+
+      materials = {
+        {
+          materialId = 123,
+          count = 10
+        }
+      },
+    },
+  },
+}

--- a/test/testdata/issues/issue-98_1.config
+++ b/test/testdata/issues/issue-98_1.config
@@ -1,0 +1,7 @@
+column_limit: 250
+indent_width: 2
+tab_width: 2
+continuation_indent_width: 2
+chop_down_table: true
+chop_down_kv_table: true
+column_table_limit: 40

--- a/test/testdata/issues/issue-98_1.lua
+++ b/test/testdata/issues/issue-98_1.lua
@@ -1,0 +1,17 @@
+test = {
+  image = "test",
+  list = {
+    {
+      ref = "testRef",
+      tags = { "tagTest" },
+      time = 10,
+
+      materials = {
+        {
+          materialId = 123,
+          count = 10
+        }
+      },
+    },
+  },
+}


### PR DESCRIPTION
by default the column_table_limit is same as column_limit.
User can set the value of column_table_limit in type int.
as discussed in [issue#98](https://github.com/Koihik/LuaFormatter/issues/98)