### PR TITLE
Search for configuration file in XDG_CONFIG_HOME.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ luarocks install --server=https://luarocks.org/dev luaformatter
       arguments to be treated as positional options
 ```
 
-The program will attempt to automatically use the current directory's `.lua-format` file if no config file is passed in the command line.
+The program will attempt to automatically use the current directory's `.lua-format` file if no config file is passed in the command line. On Linux it will use `$XDG_CONFIG_HOME/luaformatter/config.yaml` if `.lua-format` does not exist.
 In case there's no file, it will fallback to the default configuration.
 
 ### Style configure file

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <args/args.hxx>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -49,6 +50,22 @@ int main(int argc, const char* argv[]) {
             if (candidate.filename() == ".lua-format") configFileName = candidate.string();
         }
     }
+    
+#ifdef __linux__
+    if (configFileName.empty()) {
+        string conf_dir;
+        if (const char* const conf_dir_p = getenv("XDG_CONFIG_HOME")) conf_dir = conf_dir_p;
+        if (conf_dir.empty()) {
+            string home;
+            if (const char* const home_p = getenv("HOME")) home = home_p;
+            if (!home.empty()) conf_dir = home + "/.config";
+        }
+        if (!conf_dir.empty()) {
+            string candidate = conf_dir + "/luaformatter/config.yaml";
+            if (fs::exists(candidate)) configFileName = candidate;
+        }
+    }
+#endif
 
     if (configFileName.empty()) {
         if (verbose) cerr << "using default configuration" << endl;


### PR DESCRIPTION
This pull request introduces a global configuration file for Linux systems located at `$XDG_CONFIG_HOME/luaformatter/config.yaml`. If not set or empty, `$XDG_CONFIG_HOME` defaults to `$HOME/.config` as specified by the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

If this file exists, it overrides only the builtin defaults, not the `.lua-format` file. If this file does not exist or the operating system is not Linux based, the program behaves the same as before.