### PR TITLE
compile for win32 using docker and mxe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project("lua-formatter" VERSION 1.3.0 LANGUAGES CXX)
 
 option(BUILD_TESTS "set ON to build tests" ON)
 option(COVERAGE "set ON to enable coverage" ON)
+option(TEST_C++17_COMPILER "set ON to enable c++17 compiler test" ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -36,19 +37,20 @@ else()
   set(extra-libs "")
 endif()
 
-try_run(TEST_RUN_RESULT
-  TEST_COMPILE_RESULT
-  ${CMAKE_CURRENT_BINARY_DIR}/
-  ${PROJECT_SOURCE_DIR}/test/cpp17/fs.cpp
-  LINK_LIBRARIES ${extra-libs}
-  OUTPUT_VARIABLE var)
+if(TEST_C++17_COMPILER)
+  try_run(TEST_RUN_RESULT
+    TEST_COMPILE_RESULT
+    ${CMAKE_CURRENT_BINARY_DIR}/
+    ${PROJECT_SOURCE_DIR}/test/cpp17/fs.cpp
+    LINK_LIBRARIES ${extra-libs}
+    OUTPUT_VARIABLE var)
 
-message("${var}")
+  message("${var}")
 
-if(NOT "${TEST_COMPILE_RESULT}" OR (NOT "${TEST_RUN_RESULT}" EQUAL 0))
-  message(FATAL_ERROR "Your compiler does not fully support the C++17 standard and libraries")
+  if(NOT "${TEST_COMPILE_RESULT}" OR (NOT "${TEST_RUN_RESULT}" EQUAL 0))
+    message(FATAL_ERROR "Your compiler does not fully support the C++17 standard and libraries")
+  endif()
 endif()
-
 
 include_directories(
   ${PROJECT_SOURCE_DIR}/generated/

--- a/compile_win32
+++ b/compile_win32
@@ -1,0 +1,53 @@
+#!/bin/bash
+cd "${0%/*}"
+
+if [ -z "`docker image ls | grep 'compile_luaformat'`" ]; then
+
+#this step will take a while
+echo "
+FROM ubuntu:latest
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    autoconf \
+    automake \
+    autopoint \
+    bash \
+    bison \
+    bzip2 \
+    flex \
+    g++ \
+    g++-multilib \
+    gettext \
+    git \
+    gperf \
+    intltool \
+    libc6-dev-i386 \
+    libgdk-pixbuf2.0-dev \
+    libltdl-dev \
+    libssl-dev \
+    libtool-bin \
+    libxml-parser-perl \
+    lzip \
+    make \
+    openssl \
+    p7zip-full \
+    patch \
+    perl \
+    pkg-config \
+    python \
+    ruby \
+    sed \
+    unzip \
+    wget \
+    xz-utils
+
+WORKDIR /root
+RUN git clone https://github.com/mxe/mxe.git --depth 1
+WORKDIR /root/mxe
+RUN make MXE_PLUGIN_DIRS=plugins/gcc10 cc cmake -j2
+" | docker build -t compile_luaformat - || exit 1
+fi
+
+mkdir -p build.win32
+docker run --rm -v `pwd`/:/sources compile_luaformat bash -c 'cd /sources/build.win32; PATH=/root/mxe/usr/bin:$PATH; i686-w64-mingw32.static-cmake .. -DTEST_C++17_COMPILER=off; make -j2'


### PR DESCRIPTION
I needed the latest commit to be compiled for windows, so I used Docker and mxe project to cross compile for windows.
This commit can be used as a base step to use github actions to compile automatically.
The only thing that did not work out of the box is the "try_run" (to test the c++17 compiler) CmakeList option, not sure why, so I simply added an option to disable.
