### PR TITLE
Fix an example in Style-Config.md: indent_width

### DIFF
--- a/docs/Style-Config.md
+++ b/docs/Style-Config.md
@@ -35,7 +35,7 @@ end
 
 -- indent_width: 4
 function x()
-	print(1)
+    print(1)
 end
 ```
 


### PR DESCRIPTION
Fix an example in `Style-Config.md`: `indent_width`, tab character to 4 spaces as explained.