### PR TITLE
Fix configuration file fallback on Linux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -323,7 +323,8 @@ int main(int argc, const char* argv[]) {
             if (!home.empty()) {
                 conf_dir = home + "/.config";
             }
-        } else {
+        }
+        if (!conf_dir.empty()) {
             std::string candidate = conf_dir + "/luaformatter/config.yaml";
             if (fs::exists(candidate)) {
                 configFileName = candidate;


### PR DESCRIPTION
If `$XDG_CONFIG_HOME` is not set, fallback to the default of `$HOME/.config` doesn't work properly, since `conf_dir` may be modified inside the previous if statement body.