### PR TITLE
Add Four New Spacing Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,27 @@ luarocks install --server=https://luarocks.org/dev luaformatter
                                         quote
       --no-single-quote-to-double-quote Do not transform string literals to use
                                         double quote
+      --spaces-inside-functiondef-params
+                                        Put spaces on the inside of parens in
+                                        function headers
+      --no-spaces-inside-functiondef-params
+                                        Do not put spaces on the inside of
+                                        parens in function headers
+      --spaces-inside-functioncall-params
+                                        Put spaces on the inside of parens in
+                                        function calls
+      --no-spaces-inside-functioncall-params
+                                        Do not put spaces on the inside of
+                                        parens in function calls
+      --spaces-inside-table-braces      Put spaces on the inside of braces in
+                                        table constructors
+      --no-spaces-inside-table-braces   Do not put spaces on the inside of
+                                        braces in table constructors
+      --spaces-around-equals-in-field   Put spaces around the equal sign in
+                                        key/value fields
+      --no-spaces-around-equals-in-field
+                                        Do not put spaces around the equal sign
+                                        in key/value fields
       Lua scripts...                    Lua scripts to format
       "--" can be used to terminate flag options and force all following
       arguments to be treated as positional options
@@ -139,6 +160,8 @@ keep_simple_function_one_line: true
 align_args: true
 break_after_functioncall_lp: false
 break_before_functioncall_rp: false
+spaces_inside_functioncall_parens: false
+spaces_inside_functiondef_parens: false
 align_parameter: true
 chop_down_parameter: false
 break_after_functiondef_lp: false
@@ -149,11 +172,13 @@ break_before_table_rb: true
 chop_down_table: false
 chop_down_kv_table: true
 table_sep: ","
-column_table_limit: column_limit
 extra_sep_at_table_end: false
+column_table_limit: 80
+spaces_inside_table_braces: false
 break_after_operator: true
 double_quote_to_single_quote: false
 single_quote_to_double_quote: false
+spaces_around_equals_in_field: true
 ```
 ### Disable formatting for a line or block
 Sometimes it may be useful to disable automatic formatting. This is done be putting the code between `LuaFormatter off` and `LuaFormatter on` tags:

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ break_before_table_rb: true
 chop_down_table: false
 chop_down_kv_table: true
 table_sep: ","
+column_table_limit: column_limit
 extra_sep_at_table_end: false
-column_table_limit: 80
 spaces_inside_table_braces: false
 break_after_operator: true
 double_quote_to_single_quote: false

--- a/README.md
+++ b/README.md
@@ -110,16 +110,16 @@ luarocks install --server=https://luarocks.org/dev luaformatter
                                         quote
       --no-single-quote-to-double-quote Do not transform string literals to use
                                         double quote
-      --spaces-inside-functiondef-params
+      --spaces-inside-functiondef-parens
                                         Put spaces on the inside of parens in
                                         function headers
-      --no-spaces-inside-functiondef-params
+      --no-spaces-inside-functiondef-parens
                                         Do not put spaces on the inside of
                                         parens in function headers
-      --spaces-inside-functioncall-params
+      --spaces-inside-functioncall-parens
                                         Put spaces on the inside of parens in
                                         function calls
-      --no-spaces-inside-functioncall-params
+      --no-spaces-inside-functioncall-parens
                                         Do not put spaces on the inside of
                                         parens in function calls
       --spaces-inside-table-braces      Put spaces on the inside of braces in

--- a/docs/Style-Config.md
+++ b/docs/Style-Config.md
@@ -566,14 +566,21 @@ point = Point{ x = 1, y = 2 }
 type: bool, default: true
 
 Inserts spaces around the equal sign in key/value fields.
+Other assignments are not affected, though they may be
+affected by other options or behavior of the formatter.
 
 ```lua
 -- original
 x = {1, 2, 3}
+point={ x=1, y=2}
+point = Point{x=1, y=2}
+
+-- transformed (true)
+x = {1, 2, 3}
 point = {x = 1, y = 2}
 point = Point{x = 1, y = 2}
 
--- transformed
+-- transformed (false)
 x = {1, 2, 3}
 point = {x=1, y=2}
 point = Point{x=1, y=2}

--- a/docs/Style-Config.md
+++ b/docs/Style-Config.md
@@ -490,3 +490,91 @@ f "a" "b"
 require"foo"
 f"a" "b"
 ```
+
+### spaces_inside_functiondef_parens
+
+type: bool, default: false
+
+Inserts spaces inside the parenthesis in a function header.
+
+```lua
+-- original
+function foo(x, y)
+  print('hello')
+end
+
+foo = function(x, y)
+  print('hello')
+end
+
+-- transformed
+function foo( x, y )
+  print('hello')
+end
+
+foo = function( x, y )
+  print('hello')
+end
+```
+
+### spaces_inside_functioncall_parens
+
+type: bool, default: false
+
+Inserts spaces inside the parenthesis in a function call.
+
+```lua
+-- original
+function foo(x, y)
+  print('hello')
+end
+
+foo = function(x, y)
+  print('hello', 2)
+end
+
+-- transformed
+function foo(x, y)
+  print( 'hello' )
+end
+
+foo = function(x, y)
+  print( 'hello', 2 )
+end
+```
+
+### spaces_inside_table_braces
+
+type: bool, default: false
+
+Inserts spaces inside the braces in a table constructor.
+
+```lua
+-- original
+x = {1, 2, 3}
+point = {x = 1, y = 2}
+point = Point{x = 1, y = 2}
+
+-- transformed
+x = { 1, 2, 3 }
+point = { x = 1, y = 2 }
+point = Point{ x = 1, y = 2 }
+```
+
+### spaces_around_equals_in_field
+
+type: bool, default: true
+
+Inserts spaces around the equal sign in key/value fields.
+
+```lua
+-- original
+x = {1, 2, 3}
+point = {x = 1, y = 2}
+point = Point{x = 1, y = 2}
+
+-- transformed
+x = {1, 2, 3}
+point = {x=1, y=2}
+point = Point{x=1, y=2}
+```

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -23,6 +23,8 @@ Config::Config() {
     node["align_args"] = true;
     node["break_after_functioncall_lp"] = false;
     node["break_before_functioncall_rp"] = false;
+    node["spaces_inside_functioncall_parens"] = false;
+    node["spaces_inside_functiondef_parens"] = false;
 
     node["align_parameter"] = true;
     node["chop_down_parameter"] = false;
@@ -37,11 +39,14 @@ Config::Config() {
     node["table_sep"] = ",";
     node["extra_sep_at_table_end"] = false;
     node["column_table_limit"] = node["column_limit"];
+    node["spaces_inside_table_braces"] = false;
 
     node["break_after_operator"] = true;
 
     node["double_quote_to_single_quote"] = false;
     node["single_quote_to_double_quote"] = false;
+
+    node["spaces_around_equals_in_field"] = true;
 
     // Validators
     // validate integer without 0s as configuration value
@@ -139,6 +144,10 @@ Config::Config() {
     validators["double_quote_to_single_quote"] = validate_quote;
     validators["single_quote_to_double_quote"] = validate_quote;
     validators["table_sep"] = validate_character;
+    validators["spaces_inside_functioncall_parens"] = validate_boolean;
+    validators["spaces_inside_functiondef_parens"] = validate_boolean;
+    validators["spaces_inside_table_braces"] = validate_boolean;
+    validators["spaces_around_equals_in_field"] = validate_boolean;
 
     // DataType of every configuration field
     datatype["spaces_before_call"] = 'i';
@@ -167,6 +176,10 @@ Config::Config() {
     datatype["double_quote_to_single_quote"] = 'b';
     datatype["single_quote_to_double_quote"] = 'b';
     datatype["table_sep"] = 'c';
+    datatype["spaces_inside_functioncall_parens"] = 'b';
+    datatype["spaces_inside_functiondef_parens"] = 'b';
+    datatype["spaces_inside_table_braces"] = 'b';
+    datatype["spaces_around_equals_in_field"] = 'b';
 }
 
 void Config::readFromFile(const std::string& file) {

--- a/src/FormatVisitor.cpp
+++ b/src/FormatVisitor.cpp
@@ -1382,6 +1382,10 @@ antlrcpp::Any FormatVisitor::visitArgs(LuaParser::ArgsContext* ctx) {
             if (!beyondLimit || lines == 1) {
                 breakAfterLp = config_.get<bool>("break_after_functioncall_lp");
             }
+            if (config_.get<bool>("spaces_inside_functioncall_parens") &&
+                !beyondLimit && !breakAfterLp) {
+              cur_writer() << " ";
+            }
             if (breakAfterLp) {
                 // break line on '(' keeping comments
                 cur_writer() << commentAfterNewLine(ctx->LP(), INC_CONTINUATION_INDENT);
@@ -1406,6 +1410,9 @@ antlrcpp::Any FormatVisitor::visitArgs(LuaParser::ArgsContext* ctx) {
                     decContinuationIndent();
                 }
                 cur_writer() << commentAfter(ctx->explist(), "");
+            }
+            if (config_.get<bool>("spaces_inside_functioncall_parens")) {
+              cur_writer() << " ";
             }
             cur_writer() << ctx->RP()->getText();
         } else {
@@ -1452,6 +1459,10 @@ antlrcpp::Any FormatVisitor::visitFuncbody(LuaParser::FuncbodyContext* ctx) {
         if (beyondLimit) {
             breakAfterLp = config_.get<bool>("break_after_functiondef_lp");
         }
+        if (config_.get<bool>("spaces_inside_functiondef_parens") &&
+            !beyondLimit && !breakAfterLp) {
+          cur_writer() << " ";
+        }
         if (breakAfterLp) {
             cur_writer() << commentAfterNewLine(ctx->LP(), INC_CONTINUATION_INDENT);
             cur_writer() << indent();
@@ -1477,6 +1488,10 @@ antlrcpp::Any FormatVisitor::visitFuncbody(LuaParser::FuncbodyContext* ctx) {
         }
     } else {
         cur_writer() << commentAfter(ctx->LP(), "");
+    }
+    if (config_.get<bool>("spaces_inside_functiondef_parens") &&
+        ctx->parlist() != nullptr) {
+      cur_writer() << " ";
     }
     cur_writer() << ctx->RP()->getText();
     visitBlockAndComment(ctx->RP(), ctx->block(), FUNCTION_BLOCK);
@@ -1550,6 +1565,9 @@ antlrcpp::Any FormatVisitor::visitTableconstructor(LuaParser::TableconstructorCo
                 cur_writer() << commentAfterNewLine(ctx->LB(), INC_INDENT);
                 cur_writer() << indent();
             } else {
+                if (config_.get<bool>("spaces_inside_table_braces") && !breakAfterLb) {
+                  cur_writer() << " ";
+                }
                 cur_writer() << commentAfter(ctx->LB(), "");
             }
             chop_down_table_ = false;
@@ -1577,6 +1595,9 @@ antlrcpp::Any FormatVisitor::visitTableconstructor(LuaParser::TableconstructorCo
             } else {
                 cur_writer() << commentAfter(ctx->fieldlist(), "");
             }
+        }
+        if (config_.get<bool>("spaces_inside_table_braces") && !breakAfterLb) {
+          cur_writer() << " ";
         }
         cur_writer() << ctx->RB()->getText();
         chop_down_table_ = temp;
@@ -1674,21 +1695,23 @@ antlrcpp::Any FormatVisitor::visitFieldlist(LuaParser::FieldlistContext* ctx) {
 // LSB exp RSB EQL exp | NAME EQL exp | exp;
 antlrcpp::Any FormatVisitor::visitField(LuaParser::FieldContext* ctx) {
     LOG_FUNCTION_BEGIN();
+    std::string eq_space = config_.get<bool>("spaces_around_equals_in_field")
+                         ? " " : "";
     if (ctx->LSB() != nullptr) {
         cur_writer() << ctx->LSB()->getText();
         cur_writer() << commentAfter(ctx->LSB(), "");
         visitExp(ctx->exp()[0]);
         cur_writer() << commentAfter(ctx->exp()[0], "");
         cur_writer() << ctx->RSB()->getText();
-        cur_writer() << commentAfter(ctx->RSB(), " ");
+        cur_writer() << commentAfter(ctx->RSB(), eq_space);
         cur_writer() << ctx->EQL()->getText();
-        cur_writer() << commentAfter(ctx->EQL(), " ");
+        cur_writer() << commentAfter(ctx->EQL(), eq_space);
         visitExp(ctx->exp()[1]);
     } else if (ctx->NAME() != nullptr) {
         cur_writer() << ctx->NAME()->getText();
-        cur_writer() << commentAfter(ctx->NAME(), " ");
+        cur_writer() << commentAfter(ctx->NAME(), eq_space);
         cur_writer() << ctx->EQL()->getText();
-        cur_writer() << commentAfter(ctx->EQL(), " ");
+        cur_writer() << commentAfter(ctx->EQL(), eq_space);
         visitExp(ctx->exp().front());
     } else {
         visitExp(ctx->exp().front());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,6 +131,30 @@ int main(int argc, const char* argv[]) {
                               "Do not transform string literals to use double quote",
                               {"no-single-quote-to-double-quote"});
 
+    args::Group optspacesinsidefunctiondefparens(parser, "", args::Group::Validators::AtMostOne);
+    args::Flag spacesinsidefunctiondefparens(optspacesinsidefunctiondefparens, "spaces inside function header parens",
+                               "Put spaces on the inside of parens in function headers", {"spaces-inside-functiondef-params"});
+    args::Flag nospacesinsidefunctiondefparens(optspacesinsidefunctiondefparens, "spaces inside function header parens",
+                               "Do not put spaces on the inside of parens in function headers", {"no-spaces-inside-functiondef-params"});
+
+    args::Group optspacesinsidefunctioncallparens(parser, "", args::Group::Validators::AtMostOne);
+    args::Flag spacesinsidefunctioncallparens(optspacesinsidefunctioncallparens, "spaces inside function call parens",
+                               "Put spaces on the inside of parens in function calls", {"spaces-inside-functioncall-params"});
+    args::Flag nospacesinsidefunctioncallparens(optspacesinsidefunctioncallparens, "spaces inside function call parens",
+                               "Do not put spaces on the inside of parens in function calls", {"no-spaces-inside-functioncall-params"});
+
+    args::Group optspacesinsidetablebraces(parser, "", args::Group::Validators::AtMostOne);
+    args::Flag spacesinsidetablebraces(optspacesinsidetablebraces, "spaces inside table constructor braces",
+                               "Put spaces on the inside of braces in table constructors", {"spaces-inside-table-braces"});
+    args::Flag nospacesinsidetablebraces(optspacesinsidetablebraces, "spaces inside table constructor braces",
+                               "Do not put spaces on the inside of braces in table constructors", {"no-spaces-inside-table-braces"});
+
+    args::Group optspacesaroundequalsinfield(parser, "", args::Group::Validators::AtMostOne);
+    args::Flag spacesaroundequalsinfield(optspacesaroundequalsinfield, "spaces around equals sign in key/value fields",
+                               "Put spaces around the equal sign in key/value fields", {"spaces-around-equals-in-field"});
+    args::Flag nospacesaroundequalsinfield(optspacesaroundequalsinfield, "spaces around equals sign in key/value fields",
+                               "Do not put spaces around the equal sign in key/value fields", {"no-spaces-around-equals-in-field"});
+
     args::PositionalList<std::string> files(parser, "Lua scripts", "Lua scripts to format");
 
     Config config;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,15 +133,15 @@ int main(int argc, const char* argv[]) {
 
     args::Group optspacesinsidefunctiondefparens(parser, "", args::Group::Validators::AtMostOne);
     args::Flag spacesinsidefunctiondefparens(optspacesinsidefunctiondefparens, "spaces inside function header parens",
-                               "Put spaces on the inside of parens in function headers", {"spaces-inside-functiondef-params"});
+                               "Put spaces on the inside of parens in function headers", {"spaces-inside-functiondef-parens"});
     args::Flag nospacesinsidefunctiondefparens(optspacesinsidefunctiondefparens, "spaces inside function header parens",
-                               "Do not put spaces on the inside of parens in function headers", {"no-spaces-inside-functiondef-params"});
+                               "Do not put spaces on the inside of parens in function headers", {"no-spaces-inside-functiondef-parens"});
 
     args::Group optspacesinsidefunctioncallparens(parser, "", args::Group::Validators::AtMostOne);
     args::Flag spacesinsidefunctioncallparens(optspacesinsidefunctioncallparens, "spaces inside function call parens",
-                               "Put spaces on the inside of parens in function calls", {"spaces-inside-functioncall-params"});
+                               "Put spaces on the inside of parens in function calls", {"spaces-inside-functioncall-parens"});
     args::Flag nospacesinsidefunctioncallparens(optspacesinsidefunctioncallparens, "spaces inside function call parens",
-                               "Do not put spaces on the inside of parens in function calls", {"no-spaces-inside-functioncall-params"});
+                               "Do not put spaces on the inside of parens in function calls", {"no-spaces-inside-functioncall-parens"});
 
     args::Group optspacesinsidetablebraces(parser, "", args::Group::Validators::AtMostOne);
     args::Flag spacesinsidetablebraces(optspacesinsidetablebraces, "spaces inside table constructor braces",
@@ -310,6 +310,30 @@ int main(int argc, const char* argv[]) {
         argmap["single_quote_to_double_quote"] = true;
     } else if (noSingleDouble) {
         argmap["single_quote_to_double_quote"] = false;
+    }
+
+    if (spacesinsidefunctiondefparens) {
+      argmap["spaces_inside_functiondef_parens"] = true;
+    } else if (nospacesinsidefunctiondefparens) {
+      argmap["spaces_inside_functiondef_parens"] = false;
+    }
+
+    if (spacesinsidefunctioncallparens) {
+      argmap["spaces_inside_functioncall_parens"] = true;
+    } else if (nospacesinsidefunctioncallparens) {
+      argmap["spaces_inside_functioncall_parens"] = false;
+    }
+
+    if (spacesinsidetablebraces) {
+      argmap["spaces_inside_table_braces"] = true;
+    } else if (nospacesinsidetablebraces) {
+      argmap["spaces_inside_table_braces"] = false;
+    }
+
+    if (spacesaroundequalsinfield) {
+      argmap["spaces_around_equals_in_field"] = true;
+    } else if (nospacesaroundequalsinfield) {
+      argmap["spaces_around_equals_in_field"] = false;
     }
 
     std::string configFileName = args::get(cFile);

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -83,6 +83,70 @@ TEST_CASE("keep_simple_function_one_line", "config") {
     REQUIRE("function x()\n  print(1)\nend\n" == lua_format("function x() print(1) end", config));
 }
 
+TEST_CASE("spaces_inside_functiondef_parens", "config") {
+    Config config;
+    config.set("spaces_inside_functiondef_parens", true);
+
+    REQUIRE(lua_format("function x(a, b) print(1); print(1, 2) end\n", config) ==
+           "function x( a, b )\n    print(1);\n    print(1, 2)\nend\n");
+    REQUIRE(lua_format("x = function(a, b) print(1); print(1, 2) end\n", config) ==
+           "x = function( a, b )\n    print(1);\n    print(1, 2)\nend\n");
+
+    config.set("spaces_inside_functiondef_parens", false);
+    REQUIRE(lua_format("function x(a, b) print(1); print(1, 2) end\n", config) ==
+           "function x(a, b)\n    print(1);\n    print(1, 2)\nend\n");
+    REQUIRE(lua_format("x = function(a, b) print(1); print(1, 2) end\n", config) ==
+           "x = function(a, b)\n    print(1);\n    print(1, 2)\nend\n");
+}
+
+TEST_CASE("spaces_inside_functioncall_parens", "config") {
+    Config config;
+    config.set("spaces_inside_functioncall_parens", true);
+
+    REQUIRE(lua_format("function x(a, b) print(1); print(1, 2) end\n", config) ==
+           "function x(a, b)\n    print( 1 );\n    print( 1, 2 )\nend\n");
+    REQUIRE(lua_format("x = function(a, b) print(1); print(1, 2) end\n", config) ==
+           "x = function(a, b)\n    print( 1 );\n    print( 1, 2 )\nend\n");
+
+    config.set("spaces_inside_functioncall_parens", false);
+    REQUIRE(lua_format("function x(a, b) print(1); print(1, 2) end\n", config) ==
+           "function x(a, b)\n    print(1);\n    print(1, 2)\nend\n");
+    REQUIRE(lua_format("x = function(a, b) print(1); print(1, 2) end\n", config) ==
+           "x = function(a, b)\n    print(1);\n    print(1, 2)\nend\n");
+}
+
+TEST_CASE("spaces_inside_table_braces", "config") {
+    Config config;
+    config.set("spaces_before_call", 0);
+    config.set("spaces_inside_table_braces", true);
+
+    REQUIRE(lua_format("x = {}\n", config) == "x = {}\n");
+    REQUIRE(lua_format("x = {1, 2, 3}\n", config) == "x = { 1, 2, 3 }\n");
+    REQUIRE(lua_format("x = foo{1, 2, 3}\n", config) == "x = foo{ 1, 2, 3 }\n");
+    REQUIRE(lua_format("x = {x = 3, y = 5}\n", config) == "x = { x = 3, y = 5 }\n");
+    REQUIRE(lua_format("x = foo{x = 3, y = 5}\n", config) == "x = foo{ x = 3, y = 5 }\n");
+
+    config.set("spaces_inside_table_braces", false);
+    REQUIRE(lua_format("x = {}\n", config) == "x = {}\n");
+    REQUIRE(lua_format("x = {1, 2, 3}\n", config) == "x = {1, 2, 3}\n");
+    REQUIRE(lua_format("x = foo{1, 2, 3}\n", config) == "x = foo{1, 2, 3}\n");
+    REQUIRE(lua_format("x = {x = 3, y = 5}\n", config) == "x = {x = 3, y = 5}\n");
+    REQUIRE(lua_format("x = foo{x = 3, y = 5}\n", config) == "x = foo{x = 3, y = 5}\n");
+}
+
+TEST_CASE("spaces_around_equals_in_field", "config") {
+    Config config;
+    config.set("spaces_before_call", 0);
+    config.set("spaces_around_equals_in_field", true);
+
+    REQUIRE(lua_format("x = {x =3, y= 5}\n", config) == "x = {x = 3, y = 5}\n");
+    REQUIRE(lua_format("x = foo{x = 3, y=5}\n", config) == "x = foo{x = 3, y = 5}\n");
+
+    config.set("spaces_around_equals_in_field", false);
+    REQUIRE(lua_format("x = {x = 3, y =5}\n", config) == "x = {x=3, y=5}\n");
+    REQUIRE(lua_format("x = foo{x = 3, y = 5}\n", config) == "x = foo{x=3, y=5}\n");
+}
+
 TEST_CASE("args", "config") {
     Config config;
     config.set("indent_width", 2);

--- a/test/test_format_file.cpp
+++ b/test/test_format_file.cpp
@@ -57,6 +57,7 @@ TEST_FILE(PROJECT_PATH "/test/testdata/statement/semi.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/statement/shebang.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/statement/statements.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/statement/table.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/statement/inner_spaces.lua");
 
 TEST_FILE(PROJECT_PATH "/test/testdata/literals/doublequote.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/literals/singlequote.lua");

--- a/test/testdata/statement/_inner_spaces.lua
+++ b/test/testdata/statement/_inner_spaces.lua
@@ -1,0 +1,18 @@
+function foo()
+  x = 1
+  y = 2
+end
+
+function bar( x, y ) local f = function( r, s ) print( 'hello' ) end end
+
+function baz( tab ) bar( tab.x, tab.y ) end
+
+print( 1, 2, 2 )
+
+baz{ x=3, y=4 }
+
+z = { x=2, y=4 }
+
+y = { z=2, x=4 }
+
+foo()

--- a/test/testdata/statement/inner_spaces.config
+++ b/test/testdata/statement/inner_spaces.config
@@ -1,0 +1,9 @@
+indent_width:                      2
+spaces_before_call:                0
+use_tab:                           false
+
+# These are the ones under test.
+spaces_inside_functiondef_parens:  true
+spaces_inside_functioncall_parens: true
+spaces_inside_table_braces:        true
+spaces_around_equals_in_field:     false

--- a/test/testdata/statement/inner_spaces.lua
+++ b/test/testdata/statement/inner_spaces.lua
@@ -1,0 +1,27 @@
+function foo()
+  x = 1
+  y = 2
+end
+
+function bar(x, y)
+  local f = function(r, s)
+    print('hello' )
+  end
+end
+
+function baz( tab )
+  bar(tab.x, tab.y)
+end
+
+print(1, 2, 2)
+
+baz{x=3, y=4}
+
+z = {
+  x=2,
+  y = 4
+}
+
+y = {z=2, x = 4}
+
+foo()


### PR DESCRIPTION
This PR adds four new options dealing with spacing around parenthesis, braces, and equal signs.  Defaults are set so as to not change existing default formatting.  Unit tests and documentation added for each option.

### New Options
```yaml
# Option Name                      Default Value
# ------------------------------------------------------------
spaces_inside_functiondef_parens:  false
spaces_inside_functioncall_parens: false
spaces_inside_table_braces:        false
spaces_around_equals_in_field:     true
```

### spaces_inside_functiondef_parens

type: `bool`, default: `false`

Inserts spaces inside the parenthesis in a function header.

```lua
-- original
function foo(x, y)
  print('hello')
end

foo = function(x, y)
  print('hello')
end

-- transformed
function foo( x, y )
  print('hello')
end

foo = function( x, y )
  print('hello')
end
```

### spaces_inside_functioncall_parens

type: `bool`, default: `false`

Inserts spaces inside the parenthesis in a function call.

```lua
-- original
function foo(x, y)
  print('hello')
end

foo = function(x, y)
  print('hello', 2)
end

-- transformed
function foo(x, y)
  print( 'hello' )
end

foo = function(x, y)
  print( 'hello', 2 )
end
```

### spaces_inside_table_braces

type: `bool`, default: `false`

Inserts spaces inside the braces in a table constructor.

```lua
-- original
x = {1, 2, 3}
point = {x = 1, y = 2}
point = Point{x = 1, y = 2}

-- transformed
x = { 1, 2, 3 }
point = { x = 1, y = 2 }
point = Point{ x = 1, y = 2 }
```

### spaces_around_equals_in_field

type: `bool`, default: `true`

Inserts spaces around the equal sign in key/value fields.
Other assignments are not affected, though they may be
affected by other options or behavior of the formatter.

```lua
-- original
x = {1, 2, 3}
point={ x=1, y=2}
point = Point{x=1, y=2}

-- transformed (true)
x = {1, 2, 3}
point = {x = 1, y = 2}
point = Point{x = 1, y = 2}

-- transformed (false)
x = {1, 2, 3}
point = {x=1, y=2}
point = Point{x=1, y=2}
```

Fixes #160