### PR TITLE
[Feature] New format option "line_breaks_after_function_body"

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ luarocks install --server=https://luarocks.org/dev luaformatter
       --no-spaces-around-equals-in-field
                                         Do not put spaces around the equal sign
                                         in key/value fields
-      --line-breaks-after-function_body
+      --line-breaks-after-function-body
                                         Line brakes after function body
       Lua scripts...                    Lua scripts to format
       "--" can be used to terminate flag options and force all following

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ luarocks install --server=https://luarocks.org/dev luaformatter
       --no-spaces-around-equals-in-field
                                         Do not put spaces around the equal sign
                                         in key/value fields
+      --line-breaks-after-function_body
+                                        Line brakes after function body
       Lua scripts...                    Lua scripts to format
       "--" can be used to terminate flag options and force all following
       arguments to be treated as positional options
@@ -179,6 +181,7 @@ break_after_operator: true
 double_quote_to_single_quote: false
 single_quote_to_double_quote: false
 spaces_around_equals_in_field: true
+line_breaks_after_function_body: 1
 ```
 ### Disable formatting for a line or block
 Sometimes it may be useful to disable automatic formatting. This is done be putting the code between `LuaFormatter off` and `LuaFormatter on` tags:

--- a/docs/Style-Config.md
+++ b/docs/Style-Config.md
@@ -585,3 +585,32 @@ x = {1, 2, 3}
 point = {x=1, y=2}
 point = Point{x=1, y=2}
 ```
+
+### line_breaks_after_function_body
+
+type: int, default: 1
+
+Line brakes after function body
+
+```lua
+-- original(1)
+function foo()
+
+end
+
+function foo2()
+
+end
+
+-- transformed(2)
+function foo()
+
+end
+
+
+function foo2()
+
+end
+
+
+```

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -47,6 +47,7 @@ Config::Config() {
     node["single_quote_to_double_quote"] = false;
 
     node["spaces_around_equals_in_field"] = true;
+    node["line_breaks_after_function_body"] = 1;
 
     // Validators
     // validate integer without 0s as configuration value
@@ -148,6 +149,7 @@ Config::Config() {
     validators["spaces_inside_functiondef_parens"] = validate_boolean;
     validators["spaces_inside_table_braces"] = validate_boolean;
     validators["spaces_around_equals_in_field"] = validate_boolean;
+    validators["line_breaks_after_function_body"] = validate_integer;
 
     // DataType of every configuration field
     datatype["spaces_before_call"] = 'i';
@@ -180,6 +182,7 @@ Config::Config() {
     datatype["spaces_inside_functiondef_parens"] = 'b';
     datatype["spaces_inside_table_braces"] = 'b';
     datatype["spaces_around_equals_in_field"] = 'b';
+    datatype["line_breaks_after_function_body"] = 'i';
 }
 
 void Config::readFromFile(const std::string& file) {

--- a/src/FormatVisitor.cpp
+++ b/src/FormatVisitor.cpp
@@ -1492,7 +1492,15 @@ antlrcpp::Any FormatVisitor::visitFuncbody(LuaParser::FuncbodyContext* ctx) {
     }
     cur_writer() << ctx->RP()->getText();
     visitBlockAndComment(ctx->RP(), ctx->block(), FUNCTION_BLOCK);
-    cur_writer() << ctx->END()->getText();
+    cur_writer() << ctx->END()->getText();    
+    auto lineBrakesCount = config_.get<int>("line_breaks_after_function_body");
+    if(lineBrakesCount > 1)
+    {
+        for (size_t i = 1; i < lineBrakesCount; i++)
+        {
+            cur_writer() << "\n";
+        }
+    }    
     LOG_FUNCTION_END();
     return nullptr;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,7 +154,8 @@ int main(int argc, const char* argv[]) {
                                "Put spaces around the equal sign in key/value fields", {"spaces-around-equals-in-field"});
     args::Flag nospacesaroundequalsinfield(optspacesaroundequalsinfield, "spaces around equals sign in key/value fields",
                                "Do not put spaces around the equal sign in key/value fields", {"no-spaces-around-equals-in-field"});
-
+    args::ValueFlag<int> linebreaksafterfunctionbody(parser, "line breaks after function body", "Line breaks after function body", {"line-breaks-after-function-body"});
+    
     args::PositionalList<std::string> files(parser, "Lua scripts", "Lua scripts to format");
 
     Config config;
@@ -336,6 +337,10 @@ int main(int argc, const char* argv[]) {
       argmap["spaces_around_equals_in_field"] = false;
     }
 
+    if (linebreaksafterfunctionbody) {
+        argmap["line_breaks_after_function_body"] = args::get(linebreaksafterfunctionbody);
+    }
+    
     std::string configFileName = args::get(cFile);
 
     // Automatically look for a .lua-format on the current directory


### PR DESCRIPTION
Don't ask why =) I just need it.

### line_breaks_after_function_body

type: int, default: 1

Line brakes after function body

```lua
-- original(1)
function foo()
end

function foo2()
end

-- transformed(2)
function foo()
end


function foo2()
end


```