### PR TITLE
Fix bug with option spaces-inside-functioncall-parens.

### DIFF
--- a/src/FormatVisitor.cpp
+++ b/src/FormatVisitor.cpp
@@ -1375,7 +1375,7 @@ antlrcpp::Any FormatVisitor::visitArgs(LuaParser::ArgsContext* ctx) {
                 breakAfterLp = config_.get<bool>("break_after_functioncall_lp");
             }
             if (config_.get<bool>("spaces_inside_functioncall_parens") &&
-                !beyondLimit && !breakAfterLp) {
+                !breakAfterLp) {
               cur_writer() << " ";
             }
             functioncallLpHasBreak_.push_back(breakAfterLp);

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -101,18 +101,28 @@ TEST_CASE("spaces_inside_functiondef_parens", "config") {
 
 TEST_CASE("spaces_inside_functioncall_parens", "config") {
     Config config;
-    config.set("spaces_inside_functioncall_parens", true);
+    config.set("column_limit", 80);
 
+    config.set("spaces_inside_functioncall_parens", true);
     REQUIRE(lua_format("function x(a, b) print(1); print(1, 2) end\n", config) ==
            "function x(a, b)\n    print( 1 );\n    print( 1, 2 )\nend\n");
     REQUIRE(lua_format("x = function(a, b) print(1); print(1, 2) end\n", config) ==
            "x = function(a, b)\n    print( 1 );\n    print( 1, 2 )\nend\n");
+    // This tests an edge case where inserting spaces inside the parenthesis causes the
+    // result to be pushed just over the column limit.
+    REQUIRE(lua_format("module.this_is_a_really_long_lo_long_name(param1, param2, param3, param4, param5)\n", config) ==
+                     // |0        |10       |20       |30       |40       |50       |60       |70       |80
+                       "module.this_is_a_really_long_lo_long_name( param1, param2, param3, param4,\n"
+                       "                                           param5 )\n");
 
     config.set("spaces_inside_functioncall_parens", false);
     REQUIRE(lua_format("function x(a, b) print(1); print(1, 2) end\n", config) ==
            "function x(a, b)\n    print(1);\n    print(1, 2)\nend\n");
     REQUIRE(lua_format("x = function(a, b) print(1); print(1, 2) end\n", config) ==
            "x = function(a, b)\n    print(1);\n    print(1, 2)\nend\n");
+    REQUIRE(lua_format("module.this_is_a_really_long_lo_long_name(param1, param2, param3, param4, param5)\n", config) ==
+                     // |0        |10       |20       |30       |40       |50       |60       |70       |80
+                       "module.this_is_a_really_long_lo_long_name(param1, param2, param3, param4, param5)\n");
 }
 
 TEST_CASE("spaces_inside_table_braces", "config") {


### PR DESCRIPTION
When the `spaces_inside_functioncall_parens` option is enabled,
there is an edge case that does not work.  That is, when the
line that is formatted with the option off fits on a line, but then
when formatted with the option on, the length of the line gets
pushed just over the column limit.  In that case, the spaces are
not inserted properly.  This should fix that.

Added test case for this which fails without this fix.