### PR TITLE
feat: support config line_separator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+* text=auto eol=lf
 *.a filter=lfs diff=lfs merge=lfs -text

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ if(BUILD_TESTS)
     test/test_parser.cpp
     test/test_args.cpp
     test/test_validation.cpp
+    test/test_line_separator.cpp
     )
   set_target_properties(lua-format-test PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ luarocks install --server=https://luarocks.org/dev luaformatter
                                         in key/value fields
       --line-breaks-after-function-body
                                         Line brakes after function body
+      --line-separator=[line separator] input(determined by the input content),
+                                        os(Use line ending of the current
+                                        Operating system), lf(Unix style "\n"),
+                                        crlf(Windows style "\r\n"), cr(classic
+                                        Max style "\r")
       Lua scripts...                    Lua scripts to format
       "--" can be used to terminate flag options and force all following
       arguments to be treated as positional options
@@ -182,6 +187,7 @@ double_quote_to_single_quote: false
 single_quote_to_double_quote: false
 spaces_around_equals_in_field: true
 line_breaks_after_function_body: 1
+line_separator: input
 ```
 ### Disable formatting for a line or block
 Sometimes it may be useful to disable automatic formatting. This is done be putting the code between `LuaFormatter off` and `LuaFormatter on` tags:

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -49,6 +49,8 @@ Config::Config() {
     node["spaces_around_equals_in_field"] = true;
     node["line_breaks_after_function_body"] = 1;
 
+    node["line_separator"] = "input";
+
     // Validators
     // validate integer without 0s as configuration value
     auto validate_integer = [](const std::string& key, std::any elem) {
@@ -117,6 +119,15 @@ Config::Config() {
         }
         return value;
     };
+    auto validate_line_separator = [&](const std::string& key, std::any elem) {
+        (void)(key);
+        const auto value = std::any_cast<std::string>(elem);
+        if (value != "os" && value != "input" && value != "lf" && value != "cr" && value != "crlf") {
+            throw std::domain_error(
+                "[ERROR] Configuration value of line_separator should be one of os/input/lf/cr/crlf");
+        }
+        return value;
+    };
 
     // Validators
     validators["spaces_before_call"] = validate_integer_zero;
@@ -150,6 +161,7 @@ Config::Config() {
     validators["spaces_inside_table_braces"] = validate_boolean;
     validators["spaces_around_equals_in_field"] = validate_boolean;
     validators["line_breaks_after_function_body"] = validate_integer;
+    validators["line_separator"] = validate_line_separator;
 
     // DataType of every configuration field
     datatype["spaces_before_call"] = 'i';
@@ -183,6 +195,7 @@ Config::Config() {
     datatype["spaces_inside_table_braces"] = 'b';
     datatype["spaces_around_equals_in_field"] = 'b';
     datatype["line_breaks_after_function_body"] = 'i';
+    datatype["line_separator"] = 's';
 }
 
 void Config::readFromFile(const std::string& file) {
@@ -224,6 +237,11 @@ void Config::readFromFile(const std::string& file) {
                     node[key] = std::any_cast<char>(validators[key](key, value));
                     break;
                 }
+                case 's': {
+                    auto value = kv.second.as<std::string>();
+                    node[key] = std::any_cast<std::string>(validators[key](key, value));
+                    break;
+                }
             }
         }
         if (key == CTL) {
@@ -256,6 +274,11 @@ void Config::readFromMap(std::map<std::string, std::any>& mp) {
                 case 'c': {
                     assert(strcmp(kv.second.type().name(), "c") == 0);
                     node[key] = std::any_cast<char>(validators[key](key, kv.second));
+                    break;
+                }
+                case 's': {
+                    assert(strcmp(kv.second.type().name(), "s") == 0);
+                    node[key] = std::any_cast<std::string>(validators[key](key, kv.second));
                     break;
                 }
             }

--- a/src/lua-format.h
+++ b/src/lua-format.h
@@ -7,3 +7,10 @@
 
 std::string lua_format(const std::string& input, const Config& config);
 std::string lua_format(std::istream& stream, const Config& config);
+
+/// Return the line separator (LF, CRLF, CR) that appears the most
+/// When ties or the input has no newline, return in the order of LF > CRLF > CR
+std::string get_line_separator(const std::string& input);
+
+/// Return input with all line separator replaced with the specified one
+std::string convert_line_separator(const std::string& input, const std::string& line_sep);

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -283,3 +283,31 @@ TEST_CASE("read from file", "config") {
     REQUIRE("," == config.get<std::string>("table_sep"));
     REQUIRE(false == config.get<bool>("extra_sep_at_table_end"));
 }
+
+TEST_CASE("line_separator", "config") {
+    Config config;
+    config.set("indent_width", 2);
+
+    config.set("line_separator", "lf");
+    REQUIRE("function W()\n  print(1)\n  print(2)\nend\n" == lua_format("function W() print(1) print(2) end", config));
+    config.set("line_separator", "cr");
+    REQUIRE("function W()\r  print(1)\r  print(2)\rend\r" == lua_format("function W() print(1) print(2) end", config));
+    config.set("line_separator", "crlf");
+    REQUIRE("function W()\r\n  print(1)\r\n  print(2)\r\nend\r\n" == lua_format("function W() print(1) print(2) end", config));
+
+    config.set("line_separator", "input");
+    REQUIRE("function W()\n  print(1)\n  print(2)\nend\n" == lua_format("function W()\n print(1)\n print(2)\n end", config));
+    REQUIRE("function W()\r  print(1)\r  print(2)\rend\r" == lua_format("function W()\r print(1)\r print(2)\r end", config));
+    REQUIRE("function W()\r\n  print(1)\r\n  print(2)\r\nend\r\n" == lua_format("function W()\r\n print(1)\r\n print(2)\r\n end", config));
+
+    config.set("line_separator", "os");
+#ifdef _WIN32
+    REQUIRE("function W()\r\n  print(1)\r\n  print(2)\r\nend\r\n" == lua_format("function W()\n print(1)\n print(2)\n end", config));
+    REQUIRE("function W()\r\n  print(1)\r\n  print(2)\r\nend\r\n" == lua_format("function W()\r print(1)\r print(2)\r end", config));
+    REQUIRE("function W()\r\n  print(1)\r\n  print(2)\r\nend\r\n" == lua_format("function W()\r\n print(1)\r\n print(2)\r\n end", config));
+#else
+    REQUIRE("function W()\n  print(1)\n  print(2)\nend\n" == lua_format("function W()\n print(1)\n print(2)\n end", config));
+    REQUIRE("function W()\n  print(1)\n  print(2)\nend\n" == lua_format("function W()\r print(1)\r print(2)\r end", config));
+    REQUIRE("function W()\n  print(1)\n  print(2)\nend\n" == lua_format("function W()\r\n print(1)\r\n print(2)\r\n end", config));
+#endif
+}

--- a/test/test_line_separator.cpp
+++ b/test/test_line_separator.cpp
@@ -1,0 +1,44 @@
+#include <catch2/catch.hpp>
+
+#include "lua-format.h"
+
+TEST_CASE("get_line_separator", "line_separator") {
+    REQUIRE(get_line_separator("\n") == "\n");
+    REQUIRE(get_line_separator("\r") == "\r");
+    REQUIRE(get_line_separator("\r\n") == "\r\n");
+
+    REQUIRE(get_line_separator("1\n2\n3\n") == "\n");
+    REQUIRE(get_line_separator("1\r\n2\r\n3\r\n") == "\r\n");
+    REQUIRE(get_line_separator("1\r2\r3\r") == "\r");
+
+    // Different separator appears equal times
+    REQUIRE(get_line_separator("") == "\n");
+    REQUIRE(get_line_separator("\r\n\n\r") == "\n");
+    REQUIRE(get_line_separator("\n\r") == "\n");
+    REQUIRE(get_line_separator("\r\n\r") == "\r\n");
+    REQUIRE(get_line_separator("1\r\n2\n3\r") == "\n");
+
+    // Different separator appears different times
+    REQUIRE(get_line_separator("1\r\n2\r\n3\n") == "\r\n");
+    REQUIRE(get_line_separator("1\n2\r\n3\r\n") == "\r\n");
+    REQUIRE(get_line_separator("1\r2\n3\n") == "\n");
+    REQUIRE(get_line_separator("1\n2\r3\r") == "\r");
+}
+
+TEST_CASE("convert_line_separator", "line_separator") {
+    REQUIRE(convert_line_separator("", "\r\n").empty());
+    REQUIRE(convert_line_separator("", "\n").empty());
+    REQUIRE(convert_line_separator("", "\r").empty());
+
+    REQUIRE(convert_line_separator("1\r\n2\r\n3\r\n", "\n") == "1\n2\n3\n");
+    REQUIRE(convert_line_separator("1\r\n2\r\n3\r\n", "\r") == "1\r2\r3\r");
+    REQUIRE(convert_line_separator("1\r\n2\r\n3\r\n", "\r\n") == "1\r\n2\r\n3\r\n");
+
+    REQUIRE(convert_line_separator("1\n2\n3\n", "\n") == "1\n2\n3\n");
+    REQUIRE(convert_line_separator("1\n2\n3\n", "\r") == "1\r2\r3\r");
+    REQUIRE(convert_line_separator("1\n2\n3\n", "\r\n") == "1\r\n2\r\n3\r\n");
+
+    REQUIRE(convert_line_separator("1\r2\r3\r", "\n") == "1\n2\n3\n");
+    REQUIRE(convert_line_separator("1\r2\r3\r", "\r") == "1\r2\r3\r");
+    REQUIRE(convert_line_separator("1\r2\r3\r", "\r\n") == "1\r\n2\r\n3\r\n");
+}


### PR DESCRIPTION
```
Add config "line_separator" which supports the following options

input: Determine line separator by the input content. This is the default.
os: Determine line separator by the operating system
lf: Use Unix Style ("\n")
cr: Use classic Max Style ("\r")
crlf: Use Windows Style ("\r\n")

Note that the default behavior is changed.
The previous behavior is "os",
but I think "input" is a more appropriate default.
```

Some potential issues:

1. To avoid potential test issues by git autocrlf, I have modified .gitattributes to force all files to be checkouted in LF line separator.
2. The new line separator behavior is not the same as the old behavior. The old behavior determines the output line separator by the operating system (by `std::cout` in text mode). The new behavior defaults to determine by the input content's line separator. I believe the new behavior is a better default.
3.  Have I added enough tests?
4.  Not sure if my clang-format is setup correctly.  Code format may need to be fixed