### PR TITLE
Fixed align_parameter when using tabs

### DIFF
--- a/src/FormatVisitor.cpp
+++ b/src/FormatVisitor.cpp
@@ -700,22 +700,26 @@ antlrcpp::Any FormatVisitor::visitNamelist(LuaParser::NamelistContext* ctx) {
             beyondLimit = cur_columns() + length > config_.get<int>("column_limit");
         }
         if (beyondLimit) {
+            bool hasIncIndentForAlign = false;
             if (hasIncIndent) {
                 cur_writer() << commentAfterNewLine(ctx->COMMA()[i], NONE_INDENT);
-                cur_writer() << indent();
+                cur_writer() << indentWithAlign();
             } else {
                 if (config_.get<bool>("align_parameter")) {
                     cur_writer() << commentAfterNewLine(ctx->COMMA()[i], NONE_INDENT);
-                    indent_ += firstParameterIndent;
-                    cur_writer() << indent();
-                    indent_ -= firstParameterIndent;
+                    incIndentForAlign(firstParameterIndent);
+                    cur_writer() << indentWithAlign();
+                    hasIncIndentForAlign = true;
                 } else {
                     cur_writer() << commentAfterNewLine(ctx->COMMA()[i], INC_CONTINUATION_INDENT);
-                    cur_writer() << indent();
+                    cur_writer() << indentWithAlign();
                     hasIncIndent = true;
                 }
             }
             cur_writer() << ctx->NAME()[i + 1]->getText();
+            if (hasIncIndentForAlign) {
+                decIndentForAlign(firstParameterIndent);
+            }
         } else {
             cur_writer() << commentAfter(ctx->COMMA()[i], " ");
             cur_writer() << ctx->NAME()[i + 1]->getText();
@@ -779,23 +783,27 @@ antlrcpp::Any FormatVisitor::visitAttnamelist(LuaParser::AttnamelistContext* ctx
         }
         beyondLimit = cur_columns() + length > config_.get<int>("column_limit");
         if (beyondLimit) {
+            bool hasIncIndentForAlign = false;
             if (hasIncIndent) {
                 cur_writer() << commentAfterNewLine(ctx->COMMA()[i], NONE_INDENT);
-                cur_writer() << indent();
+                cur_writer() << indentWithAlign();
             } else {
                 if (config_.get<bool>("align_parameter")) {
                     cur_writer() << commentAfterNewLine(ctx->COMMA()[i], NONE_INDENT);
-                    indent_ += firstParameterIndent;
-                    cur_writer() << indent();
-                    indent_ -= firstParameterIndent;
+                    incIndentForAlign(firstParameterIndent);
+                    cur_writer() << indentWithAlign();
+                    hasIncIndentForAlign = true;
                 } else {
                     cur_writer() << commentAfterNewLine(ctx->COMMA()[i], INC_CONTINUATION_INDENT);
-                    cur_writer() << indent();
+                    cur_writer() << indentWithAlign();
                     hasIncIndent = true;
                 }
             }
             cur_writer() << ctx->NAME()[i + 1]->getText();
             cur_writer() << ctx->attrib()[i + 1]->getText();
+            if (hasIncIndentForAlign) {
+                decIndentForAlign(firstParameterIndent);
+            }
         } else {
             cur_writer() << commentAfter(ctx->COMMA()[i], " ");
             cur_writer() << ctx->NAME()[i + 1]->getText();

--- a/test/test_format_file.cpp
+++ b/test/test_format_file.cpp
@@ -86,6 +86,7 @@ TEST_FILE(PROJECT_PATH "/test/testdata/issues/issue-168.lua");
 
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/PR-100.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/issues/PR-108.lua");
+TEST_FILE(PROJECT_PATH "/test/testdata/issues/PR-181.lua");
 
 TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/default.lua");
 TEST_FILE(PROJECT_PATH "/test/testdata/keep_simple_block_one_line/keep_simple_function_one_line_false.lua");

--- a/test/testdata/issues/PR-181.config
+++ b/test/testdata/issues/PR-181.config
@@ -1,0 +1,6 @@
+column_limit: 80
+indent_width: 1
+use_tab: true
+tab_width: 4
+keep_simple_function_one_line: false
+align_parameter: true

--- a/test/testdata/issues/PR-181.lua
+++ b/test/testdata/issues/PR-181.lua
@@ -1,0 +1,5 @@
+do
+	function function_with_long_name(long_parameter_1, long_parameter_2, long_parameter_3, long_parameter_4, long_parameter_5)
+		foobar()
+	end
+end

--- a/test/testdata/issues/_PR-181.lua
+++ b/test/testdata/issues/_PR-181.lua
@@ -1,0 +1,7 @@
+do
+	function function_with_long_name(long_parameter_1, long_parameter_2,
+	                                 long_parameter_3, long_parameter_4,
+	                                 long_parameter_5)
+		foobar()
+	end
+end


### PR DESCRIPTION
When `use_tab` is configured, `align_parameter` does not respect the proper alignment and instead writes as many tabs as if they were spaces, massively offsetting the second line to the right in most cases.
This change copies the behavior from `align_args` into the `align_parameter` code.