### PR TITLE
Minor change to chop_down_kv_table behavior

### DIFF
--- a/src/FormatVisitor.cpp
+++ b/src/FormatVisitor.cpp
@@ -1592,6 +1592,11 @@ antlrcpp::Any FormatVisitor::visitTableconstructor(LuaParser::TableconstructorCo
         if (beyondLimit) {
             breakAfterLb = config_.get<bool>("break_after_table_lb");
             chopDown = config_.get<bool>("chop_down_table") || (config_.get<bool>("chop_down_kv_table") && containsKv);
+        } else {
+            if (config_.get<bool>("chop_down_kv_table") && containsKv) {
+                breakAfterLb = config_.get<bool>("break_after_table_lb");
+                chopDown = true;
+            }
         }
         if (chopDown) {
             cur_writer() << commentAfterNewLine(ctx->LB(), INC_INDENT);


### PR DESCRIPTION
Allow chop_down_kv_table to work even when !beyondLimit.
Fixes #195

I'm not 100% sure if this is the preferred way to fix this but for me it works.

The [documentation](https://github.com/Koihik/LuaFormatter/blob/master/docs/Style-Config.md#chop_down_kv_table) does not say that the chop_down_kv_table option should be effected by the column_limit but as [currently implemented](https://github.com/Koihik/LuaFormatter/blob/master/src/FormatVisitor.cpp#L1592) chop_down_kv_table is not checked until beyondLimit == true.

This small change seems to work for me and makes this work as documented.
If there are any changes I should make to my commit please let me know and I will be happy to make them.

Thank you!