### PR TITLE
Fix column_table_limit behavior

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -38,7 +38,7 @@ Config::Config() {
     node["chop_down_kv_table"] = true;
     node["table_sep"] = ",";
     node["extra_sep_at_table_end"] = false;
-    node["column_table_limit"] = node["column_limit"];
+    node["column_table_limit"] = 0; // follows column_limit by default
     node["spaces_inside_table_braces"] = false;
 
     node["break_after_operator"] = true;
@@ -215,9 +215,6 @@ void Config::readFromFile(const std::string& file) {
     YAML::Node n = YAML::LoadFile(file);
 
     // Keys are always strings
-    bool given = false;
-    std::string CTL = "column_table_limit";
-    std::string CL = "column_limit";
     for (const auto& kv : n) {
         auto key = kv.first.as<std::string>();
         if (node[key]) {
@@ -244,19 +241,10 @@ void Config::readFromFile(const std::string& file) {
                 }
             }
         }
-        if (key == CTL) {
-            given = true;
-        }
-    }
-    if (!given) {
-        node[CTL] = node[CL];
     }
 }
 
 void Config::readFromMap(std::map<std::string, std::any>& mp) {
-    bool given = false;
-    std::string CTL = "column_table_limit";
-    std::string CL = "column_limit";
     for (const auto& kv : mp) {
         auto key = kv.first;
         if (node[key]) {
@@ -283,23 +271,17 @@ void Config::readFromMap(std::map<std::string, std::any>& mp) {
                 }
             }
         }
-        if (key == CTL) {
-            given = true;
-        }
-    }
-    if (!given) {
-        node[CTL] = node[CL];
     }
 }
 
 void Config::dumpCurrent(std::ofstream& fout) {
-   for (const auto& kv : node) {
-      fout << kv.first << ": " << kv.second << std::endl;
-   }
+    for (const auto& kv : node) {
+        fout << kv.first << ": " << kv.second << std::endl;
+    }
 }
 
 void Config::dumpCurrent(std::ostream& out) {
-   for (const auto& kv : node) {
-      out << kv.first << ": " << kv.second << std::endl;
-   }
+    for (const auto& kv : node) {
+        out << kv.first << ": " << kv.second << std::endl;
+    }
 }

--- a/src/FormatVisitor.cpp
+++ b/src/FormatVisitor.cpp
@@ -1586,7 +1586,11 @@ antlrcpp::Any FormatVisitor::visitTableconstructor(LuaParser::TableconstructorCo
             int length = cur_writer().firstLineColumn();
             int lines = cur_writer().lines();
             popWriter();
-            beyondLimit = cur_columns() + length > config_.get<int>("column_table_limit") || lines > 1;
+            auto column_table_limit = config_.get<int>("column_table_limit");
+            if (!column_table_limit) {
+                column_table_limit = config_.get<int>("column_limit");
+            }
+            beyondLimit = cur_columns() + length > column_table_limit || lines > 1;
         }
         bool breakAfterLb = false;
         if (beyondLimit) {
@@ -1692,7 +1696,11 @@ antlrcpp::Any FormatVisitor::visitFieldlist(LuaParser::FieldlistContext* ctx) {
         if (i != n - 1 || config_.get<bool>("extra_sep_at_table_end")) {
             length++;  // calc a ',' if exp >1
         }
-        beyondLimit = cur_columns() + length > config_.get<int>("column_table_limit");
+        auto column_table_limit = config_.get<int>("column_table_limit");
+        if (!column_table_limit) {
+            column_table_limit = config_.get<int>("column_limit");
+        }
+        beyondLimit = cur_columns() + length > column_table_limit;
         if (beyondLimit) {
             if (config_.get<bool>("align_table_field")) {
                 cur_writer() << commentAfterNewLine(ctx->fieldsep()[i - 1], NONE_INDENT);


### PR DESCRIPTION
Currently, changing `column_table_limit` changes `column_limit` as well. This is because the two options share the same node:
https://github.com/Koihik/LuaFormatter/blob/5ab5de2eab4af5241fbb2beb9eee69d039d25263/src/Config.cpp#L41

This PR introduces a special value of 0 for `column_table_limit`, in which case `column_limit` will be used instead.

While a nicer solution is definitely possible, this works well enough for this specific case, and doesn't require too many changes to the config system.

Fixes #151.