### PR TITLE
Disable tests for Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,10 @@ install(TARGETS lua-format
   RUNTIME DESTINATION bin
   )
 
+if(APPLE AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(aarch64|arm64)$")
+    set(BUILD_TESTS OFF)
+endif()
+
 if(BUILD_TESTS)
   message("BUILD_TESTS enabled.")
   enable_testing()


### PR DESCRIPTION
Trying to compile Catch2 under Apple Silicon seems to generate the wrong
instructions. The problem does indeed lie with Catch2, but as this
affects multiple users and doesn't seem to have any drawbacks; the 
immediate fix is here (and it's outside of my knowledge as to why it fails)

Another (more preferable) idea is to just add this to the rockspec instead.

Ref #199
Ref #180