### PR TITLE
 Add pre-commit hook to enable LuaFormatter for pre-commit.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: luaformatter
+    name: LuaFormatter
+    description: Format Lua code to a set style
+    entry: lua-format -i
+    language: lua
+    types: [lua]


### PR DESCRIPTION
Hello! I've been working with the maintainer of [pre-commit](https://pre-commit.com/) to add official Lua support for the pre-commit tool. With pre-commit, a developer or team can choose to run hooks that will execute before a change is committed to git.

Support for Lua in pre-commit was literally added an hour ago as of this PR submission in https://github.com/pre-commit/pre-commit/pull/2158, so this change is hot off the presses.

I believe that LuaFormatter would be a fantastic tool to work with pre-commit since running a code formatter is a very common thing to do before committing.

This PR adds a hooks definition file that will allow any project to use lua-format with pre-commit. I ran a local test on one of my projects to confirm the behavior. I've included the output with no changes (i.e. already formatted code) and a test where the formatter updates the output.

Thanks for the consideration.

No formatting changes:
```bash
atlas git:(main) ✗ pre-commit try-repo ../LuaFormatter luaformatter
===============================================================================
Using config:
===============================================================================
repos:
-   repo: ../LuaFormatter
    rev: ad94bea01ca027ca46541af727e15d002aa5ce74
    hooks:
    -   id: luaformatter
===============================================================================
[INFO] Initializing environment for ../LuaFormatter.
[INFO] Installing environment for ../LuaFormatter.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
LuaFormatter.............................................................Passed
```

Auto-formatted:
```bash
atlas git:(main) ✗ pre-commit try-repo ../LuaFormatter luaformatter
===============================================================================
Using config:
===============================================================================
repos:
-   repo: ../LuaFormatter
    rev: ad94bea01ca027ca46541af727e15d002aa5ce74
    hooks:
    -   id: luaformatter
===============================================================================
[INFO] Initializing environment for ../LuaFormatter.
[INFO] Installing environment for ../LuaFormatter.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
LuaFormatter.............................................................Failed
- hook id: luaformatter
- files were modified by this hook
```

The auto-formatted change acts as a failure so that a dev can review the diff of what the lua-format command did before they commit the changes.

The output during the first run is much noisier than subsequent runs. Typically, after the environment is configured by the first run, users will only see a line like:

```bash
LuaFormatter.............................................................Passed
```
