### PR TITLE
Fix clone

### DIFF
--- a/luaformatter-scm-1.rockspec
+++ b/luaformatter-scm-1.rockspec
@@ -2,7 +2,7 @@ rockspec_format = "3.0"
 package = "LuaFormatter"
 version = "scm-1"
 source = {
-   url = "https://github.com/Koihik/LuaFormatter.git"
+   url = "https://github.com/Koihik/LuaFormatter"
 }
 description = {
    summary = "Reformats your Lua source code.",

--- a/luaformatter-scm-1.rockspec
+++ b/luaformatter-scm-1.rockspec
@@ -2,7 +2,7 @@ rockspec_format = "3.0"
 package = "LuaFormatter"
 version = "scm-1"
 source = {
-   url = "git://github.com/Koihik/LuaFormatter.git"
+   url = "https://github.com/Koihik/LuaFormatter.git"
 }
 description = {
    summary = "Reformats your Lua source code.",


### PR DESCRIPTION
$ luarocks install --server=https://luarocks.org/dev luaformatter
Installing https://luarocks.org/dev/luaformatter-scm-1.rockspec

Cloning into 'LuaFormatter'...
fatal: Erro remoto:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.