### PR TITLE
Only transform quotes in characters between string delimiters

### DIFF
--- a/test/lua/issues/_issue-250.lua
+++ b/test/lua/issues/_issue-250.lua
@@ -1,0 +1,4 @@
+globals.regexIgnorePaths = {
+    "^[a-z]:\\\\users\\\\.*\\\\appdata\\\\",
+    "^[a-z]:\\\\users\\\\.*\\\\downloads\\\\",
+}

--- a/test/lua/issues/issue-250.config
+++ b/test/lua/issues/issue-250.config
@@ -1,0 +1,1 @@
+single_quote_to_double_quote: true

--- a/test/lua/issues/issue-250.lua
+++ b/test/lua/issues/issue-250.lua
@@ -1,0 +1,4 @@
+globals.regexIgnorePaths = {
+    '^[a-z]:\\\\users\\\\.*\\\\appdata\\\\',
+    '^[a-z]:\\\\users\\\\.*\\\\downloads\\\\',
+}


### PR DESCRIPTION
This PR changes the regex replacements to only replace quotes between the quotes for the string delimiters.

This removes the need for the extra escape transformation, which fixes #250.