### PR TITLE
Update docs and validation for column_table_limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ break_before_table_rb: true
 chop_down_table: false
 chop_down_kv_table: true
 table_sep: ","
-column_table_limit: column_limit
+column_table_limit: 0
 extra_sep_at_table_end: false
 spaces_inside_table_braces: false
 break_after_operator: true

--- a/docs/Style-Config.md
+++ b/docs/Style-Config.md
@@ -327,12 +327,13 @@ x = {
 ```
 ### column_table_limit
 
-type: int, default: column_limit
+type: int, default: 0
 
-The column limit of each line of a table. Default value the same as column_limit value.
+The column limit of each line of a table.
+If set to 0 (the default), the value of `column_limit` is used.
 
 ```lua
---column_table_limit: column_limit
+--column_table_limit: 0
 test = {
   image = "test",
   list = {

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -135,7 +135,7 @@ Config::Config() {
     validators["indent_width"] = validate_integer_zero;
     validators["tab_width"] = validate_tab_width;
     validators["continuation_indent_width"] = validate_integer_zero;
-    validators["column_table_limit"] = validate_integer;
+    validators["column_table_limit"] = validate_integer_zero;
     validators["use_tab"] = validate_use_tab;
     validators["keep_simple_control_block_one_line"] = validate_boolean;
     validators["keep_simple_function_one_line"] = validate_boolean;

--- a/test/config/column_table_limit.config
+++ b/test/config/column_table_limit.config
@@ -1,1 +1,1 @@
-column_table_limit: 0
+column_table_limit: -20

--- a/test/test_validation.cpp
+++ b/test/test_validation.cpp
@@ -12,17 +12,17 @@ TEST_CASE("gt0 validator", "[config_validator]") {
     Config config;
     REQUIRE_THROWS_WITH(config.readFromFile(configFileName),
                         "[ERROR] Configuration value is out of range. Must be a positive integer greater than 0.");
-
-    std::string configFileName2(PROJECT_PATH "/test/config/column_table_limit.config");
-    Config config2;
-    REQUIRE_THROWS_WITH(config2.readFromFile(configFileName2),
-                        "[ERROR] Configuration value is out of range. Must be a positive integer greater than 0.");
 }
 
 TEST_CASE("ge0 validator", "[config_validator]") {
     std::string configFileName(PROJECT_PATH "/test/config/indent_width.config");
     Config config;
     REQUIRE_THROWS_WITH(config.readFromFile(configFileName),
+                        "[ERROR] Configuration value is out of range. Must be a positive integer.");
+
+    std::string configFileName2(PROJECT_PATH "/test/config/column_table_limit.config");
+    Config config2;
+    REQUIRE_THROWS_WITH(config2.readFromFile(configFileName2),
                         "[ERROR] Configuration value is out of range. Must be a positive integer.");
 }
 


### PR DESCRIPTION
The behavior of the `column_table_limit` configuration parameter and its default value were changed in PR #217. This broke users' configs (see #226) since the changes were not echoed to the docs and the corresponding validator wasn't updated. This PR cleans up after it.

Fixes #226.