### PR TITLE
fix needKeepBlockOneLine

### DIFF
--- a/src/visitor/FormatVisitor.cpp
+++ b/src/visitor/FormatVisitor.cpp
@@ -177,6 +177,8 @@ void FormatVisitor::pushWriterWithColumn() {
 void FormatVisitor::popWriter() {
     SourceWriter* writer = writers_.back();
     writers_.pop_back();
+    if(tmpTotalLines_ > 0) tmpTotalLines_ --;
+    tmpTotalLines_ += writer->lines();
     delete writer;
 }
 
@@ -329,11 +331,13 @@ bool FormatVisitor::needKeepBlockOneLine(tree::ParseTree* previousNode, LuaParse
     if (fastTestColumnLimit(ctx)) {
         return false;
     }
+    resetTmpTotalLines();
     pushWriter();
     visitBlock(ctx);
     int length = cur_writer().firstLineColumn();
-    int lines = cur_writer().lines();
     popWriter();
+    int lines = tmpTotalLines();
+
     if (cur_columns() + length > config_.get<int>("column_limit") || lines > 1) {
         return false;
     }

--- a/src/visitor/FormatVisitor.h
+++ b/src/visitor/FormatVisitor.h
@@ -85,6 +85,9 @@ class FormatVisitor : public LuaBaseVisitor {
     // stack to record is break_after_functioncall_lp has break the line
     std::vector<bool> functioncallLpHasBreak_;
 
+    // Used for accumulating the lines written by multiple writers
+    int tmpTotalLines_;
+
     int indent_ = 0;
     int indentForAlign_ = 0;
     const std::vector<Token*>& tokens_;
@@ -116,6 +119,9 @@ class FormatVisitor : public LuaBaseVisitor {
     void decContinuationIndent();
     void incIndentForAlign(int indent);
     void decIndentForAlign(int indent);
+
+    void resetTmpTotalLines() {tmpTotalLines_ = 0;}
+    int tmpTotalLines() const {return tmpTotalLines_;}
 
     // Auxiliary to visitFunctioncall and visitPrefixexp
     std::string buildFirstArgumentWs(std::vector<LuaParser::NameAndArgsContext*> v);


### PR DESCRIPTION
In needKeepBlockOneLine, when visiting a block, the internal function actually calls pushWriter multiple times recursively. 
However, in the end, only the first write's lines() is taken, causing a very long block to be serialized and mistakenly determined as being able to be written in one line.

For example,
before fix, 
it actually only considers the condition following the if for evaluation, and does not judge the block after then.
````
if not _G.________________next_event_it then _G.________________next_event_it =
    0 end
````
