### PR TITLE
fix: look for a .lua-format in the directory without permissions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -406,11 +406,15 @@ int main(int argc, const char* argv[]) {
     if (configFileName.empty()) {
         fs::path current = fs::current_path();
         while (configFileName.empty()) {
-            for (const auto& entry : fs::directory_iterator(current)) {
-                const fs::path& candidate = entry.path();
-                if (candidate.filename() == ".lua-format") {
-                    configFileName = candidate.string();
+            try {
+                for (const auto& entry : fs::directory_iterator(current)) {
+                    const fs::path& candidate = entry.path();
+                    if (candidate.filename() == ".lua-format") {
+                        configFileName = candidate.string();
+                    }
                 }
+            } catch(const fs::filesystem_error&) {
+                break;
             }
 
             fs::path parent = current.parent_path();


### PR DESCRIPTION
## Procedure

```bash
~/tree/LuaFormatter $ uname -a
Linux localhost 4.14.141-ga540ec5 #1 SMP PREEMPT Thu Feb 18 12:35:08 CST 2021 aarch64 Android
~/tree/LuaFormatter $ pwd
/data/data/com.termux/files/home/tree/LuaFormatter
~/tree/LuaFormatter $ ls /data/data
ls: cannot open directory '/data/data': Permission denied
~/tree/LuaFormatter $ build/lua-format
terminating with uncaught exception of type std::__ndk1::__fs::filesystem::filesystem_error: filesystem error: in directory_iterator::directory_iterator(...): Permission denied [/data/data]
Aborted
```

